### PR TITLE
add pyproject.toml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,5 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+.idea/

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,0 +1,2950 @@
+[[package]]
+name = "black"
+version = "21.9b0"
+description = "The uncompromising code formatter."
+category = "dev"
+optional = false
+python-versions = ">=3.6.2"
+
+[package.dependencies]
+click = ">=7.1.2"
+mypy-extensions = ">=0.4.3"
+pathspec = ">=0.9.0,<1"
+platformdirs = ">=2"
+regex = ">=2020.1.8"
+tomli = ">=0.2.6,<2.0.0"
+typing-extensions = [
+    {version = ">=3.10.0.0", markers = "python_version < \"3.10\""},
+    {version = "!=3.10.0.1", markers = "python_version >= \"3.10\""},
+]
+
+[package.extras]
+colorama = ["colorama (>=0.4.3)"]
+d = ["aiohttp (>=3.6.0)", "aiohttp-cors (>=0.4.0)"]
+jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
+python2 = ["typed-ast (>=1.4.2)"]
+uvloop = ["uvloop (>=0.15.2)"]
+
+[[package]]
+name = "click"
+version = "8.0.1"
+description = "Composable command line interface toolkit"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+colorama = {version = "*", markers = "platform_system == \"Windows\""}
+
+[[package]]
+name = "colorama"
+version = "0.4.4"
+description = "Cross-platform colored terminal text."
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[[package]]
+name = "flake8"
+version = "3.9.2"
+description = "the modular source code checker: pep8 pyflakes and co"
+category = "dev"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
+
+[package.dependencies]
+mccabe = ">=0.6.0,<0.7.0"
+pycodestyle = ">=2.7.0,<2.8.0"
+pyflakes = ">=2.3.0,<2.4.0"
+
+[[package]]
+name = "imutils"
+version = "0.5.4"
+description = "A series of convenience functions to make basic image processing functions such as translation, rotation, resizing, skeletonization, displaying Matplotlib images, sorting contours, detecting edges, and much more easier with OpenCV and both Python 2.7 and Python 3."
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "isort"
+version = "5.9.3"
+description = "A Python utility / library to sort Python imports."
+category = "dev"
+optional = false
+python-versions = ">=3.6.1,<4.0"
+
+[package.extras]
+pipfile_deprecated_finder = ["pipreqs", "requirementslib"]
+requirements_deprecated_finder = ["pipreqs", "pip-api"]
+colors = ["colorama (>=0.4.3,<0.5.0)"]
+plugins = ["setuptools"]
+
+[[package]]
+name = "mccabe"
+version = "0.6.1"
+description = "McCabe checker, plugin for flake8"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "mouseinfo"
+version = "0.1.3"
+description = "An application to display XY position and RGB color information for the pixel currently under the mouse. Works on Python 2 and 3."
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+pyperclip = "*"
+python3-Xlib = {version = "*", markers = "platform_system == \"Linux\" and python_version >= \"3.0\""}
+rubicon-objc = {version = "*", markers = "platform_system == \"Darwin\""}
+
+[[package]]
+name = "mypy"
+version = "0.910"
+description = "Optional static typing for Python"
+category = "dev"
+optional = false
+python-versions = ">=3.5"
+
+[package.dependencies]
+mypy-extensions = ">=0.4.3,<0.5.0"
+toml = "*"
+typing-extensions = ">=3.7.4"
+
+[package.extras]
+dmypy = ["psutil (>=4.0)"]
+python2 = ["typed-ast (>=1.4.0,<1.5.0)"]
+
+[[package]]
+name = "mypy-extensions"
+version = "0.4.3"
+description = "Experimental type system extensions for programs checked with the mypy typechecker."
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "numpy"
+version = "1.21.2"
+description = "NumPy is the fundamental package for array computing with Python."
+category = "main"
+optional = false
+python-versions = ">=3.7,<3.11"
+
+[[package]]
+name = "opencv-python"
+version = "4.5.3.56"
+description = "Wrapper package for OpenCV python bindings."
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+numpy = ">=1.21.0"
+
+[[package]]
+name = "pathspec"
+version = "0.9.0"
+description = "Utility library for gitignore style pattern matching of file paths."
+category = "dev"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
+
+[[package]]
+name = "platformdirs"
+version = "2.4.0"
+description = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.extras]
+docs = ["Sphinx (>=4)", "furo (>=2021.7.5b38)", "proselint (>=0.10.2)", "sphinx-autodoc-typehints (>=1.12)"]
+test = ["appdirs (==1.4.4)", "pytest (>=6)", "pytest-cov (>=2.7)", "pytest-mock (>=3.6)"]
+
+[[package]]
+name = "pyautogui"
+version = "0.9.53"
+description = "PyAutoGUI lets Python control the mouse and keyboard, and other GUI automation tasks. For Windows, macOS, and Linux, on Python 3 and 2."
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+mouseinfo = "*"
+pygetwindow = ">=0.0.5"
+pymsgbox = "*"
+pyobjc = {version = "*", markers = "platform_system == \"Darwin\""}
+pyobjc-core = {version = "*", markers = "platform_system == \"Darwin\""}
+pyscreeze = ">=0.1.21"
+python3-Xlib = {version = "*", markers = "platform_system == \"Linux\" and python_version >= \"3.0\""}
+PyTweening = ">=1.0.1"
+
+[[package]]
+name = "pycodestyle"
+version = "2.7.0"
+description = "Python style guide checker"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
+name = "pyflakes"
+version = "2.3.1"
+description = "passive checker of Python programs"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
+name = "pygetwindow"
+version = "0.0.9"
+description = "A simple, cross-platform module for obtaining GUI information on application's windows."
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+pyrect = "*"
+
+[[package]]
+name = "pymsgbox"
+version = "1.0.9"
+description = "A simple, cross-platform, pure Python module for JavaScript-like message boxes."
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "pyobjc"
+version = "7.3"
+description = "Python<->ObjC Interoperability Module"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = "7.3"
+pyobjc-framework-Accessibility = {version = "7.3", markers = "platform_release >= \"20.0\""}
+pyobjc-framework-Accounts = {version = "7.3", markers = "platform_release >= \"12.0\""}
+pyobjc-framework-AddressBook = "7.3"
+pyobjc-framework-AdServices = {version = "7.3", markers = "platform_release >= \"20.0\""}
+pyobjc-framework-AdSupport = {version = "7.3", markers = "platform_release >= \"18.0\""}
+pyobjc-framework-AppleScriptKit = "7.3"
+pyobjc-framework-AppleScriptObjC = {version = "7.3", markers = "platform_release >= \"10.0\""}
+pyobjc-framework-ApplicationServices = "7.3"
+pyobjc-framework-AppTrackingTransparency = {version = "7.3", markers = "platform_release >= \"20.0\""}
+pyobjc-framework-AuthenticationServices = {version = "7.3", markers = "platform_release >= \"19.0\""}
+pyobjc-framework-AutomaticAssessmentConfiguration = {version = "7.3", markers = "platform_release >= \"19.0\""}
+pyobjc-framework-Automator = "7.3"
+pyobjc-framework-AVFoundation = {version = "7.3", markers = "platform_release >= \"11.0\""}
+pyobjc-framework-AVKit = {version = "7.3", markers = "platform_release >= \"13.0\""}
+pyobjc-framework-BusinessChat = {version = "7.3", markers = "platform_release >= \"18.0\""}
+pyobjc-framework-CalendarStore = {version = "7.3", markers = "platform_release >= \"9.0\""}
+pyobjc-framework-CallKit = {version = "7.3", markers = "platform_release >= \"20.0\""}
+pyobjc-framework-CFNetwork = "7.3"
+pyobjc-framework-ClassKit = {version = "7.3", markers = "platform_release >= \"20.0\""}
+pyobjc-framework-CloudKit = {version = "7.3", markers = "platform_release >= \"14.0\""}
+pyobjc-framework-Cocoa = "7.3"
+pyobjc-framework-Collaboration = {version = "7.3", markers = "platform_release >= \"9.0\""}
+pyobjc-framework-ColorSync = {version = "7.3", markers = "platform_release >= \"17.0\""}
+pyobjc-framework-Contacts = {version = "7.3", markers = "platform_release >= \"15.0\""}
+pyobjc-framework-ContactsUI = {version = "7.3", markers = "platform_release >= \"15.0\""}
+pyobjc-framework-CoreAudio = "7.3"
+pyobjc-framework-CoreAudioKit = "7.3"
+pyobjc-framework-CoreBluetooth = {version = "7.3", markers = "platform_release >= \"14.0\""}
+pyobjc-framework-CoreData = "7.3"
+pyobjc-framework-CoreHaptics = {version = "7.3", markers = "platform_release >= \"19.0\""}
+pyobjc-framework-CoreLocation = {version = "7.3", markers = "platform_release >= \"10.0\""}
+pyobjc-framework-CoreMedia = {version = "7.3", markers = "platform_release >= \"11.0\""}
+pyobjc-framework-CoreMediaIO = {version = "7.3", markers = "platform_release >= \"11.0\""}
+pyobjc-framework-CoreMIDI = "7.3"
+pyobjc-framework-CoreML = {version = "7.3", markers = "platform_release >= \"17.0\""}
+pyobjc-framework-CoreMotion = {version = "7.3", markers = "platform_release >= \"19.0\""}
+pyobjc-framework-CoreServices = "7.3"
+pyobjc-framework-CoreSpotlight = {version = "7.3", markers = "platform_release >= \"17.0\""}
+pyobjc-framework-CoreText = "7.3"
+pyobjc-framework-CoreWLAN = {version = "7.3", markers = "platform_release >= \"10.0\""}
+pyobjc-framework-CryptoTokenKit = {version = "7.3", markers = "platform_release >= \"14.0\""}
+pyobjc-framework-DeviceCheck = {version = "7.3", markers = "platform_release >= \"19.0\""}
+pyobjc-framework-DictionaryServices = {version = "7.3", markers = "platform_release >= \"9.0\""}
+pyobjc-framework-DiscRecording = "7.3"
+pyobjc-framework-DiscRecordingUI = "7.3"
+pyobjc-framework-DiskArbitration = "7.3"
+pyobjc-framework-DVDPlayback = "7.3"
+pyobjc-framework-EventKit = {version = "7.3", markers = "platform_release >= \"12.0\""}
+pyobjc-framework-ExceptionHandling = "7.3"
+pyobjc-framework-ExecutionPolicy = {version = "7.3", markers = "platform_release >= \"19.0\""}
+pyobjc-framework-ExternalAccessory = {version = "7.3", markers = "platform_release >= \"17.0\""}
+pyobjc-framework-FileProvider = {version = "7.3", markers = "platform_release >= \"19.0\""}
+pyobjc-framework-FileProviderUI = {version = "7.3", markers = "platform_release >= \"19.0\""}
+pyobjc-framework-FinderSync = {version = "7.3", markers = "platform_release >= \"14.0\""}
+pyobjc-framework-FSEvents = {version = "7.3", markers = "platform_release >= \"9.0\""}
+pyobjc-framework-GameCenter = {version = "7.3", markers = "platform_release >= \"12.0\""}
+pyobjc-framework-GameController = {version = "7.3", markers = "platform_release >= \"13.0\""}
+pyobjc-framework-GameKit = {version = "7.3", markers = "platform_release >= \"12.0\""}
+pyobjc-framework-GameplayKit = {version = "7.3", markers = "platform_release >= \"15.0\""}
+pyobjc-framework-ImageCaptureCore = {version = "7.3", markers = "platform_release >= \"10.0\""}
+pyobjc-framework-IMServicePlugIn = {version = "7.3", markers = "platform_release >= \"11.0\""}
+pyobjc-framework-InputMethodKit = {version = "7.3", markers = "platform_release >= \"9.0\""}
+pyobjc-framework-InstallerPlugins = "7.3"
+pyobjc-framework-InstantMessage = {version = "7.3", markers = "platform_release >= \"9.0\""}
+pyobjc-framework-Intents = {version = "7.3", markers = "platform_release >= \"16.0\""}
+pyobjc-framework-InterfaceBuilderKit = {version = "7.3", markers = "platform_release >= \"9.0\" and platform_release < \"11.0\""}
+pyobjc-framework-IOSurface = {version = "7.3", markers = "platform_release >= \"10.0\""}
+pyobjc-framework-iTunesLibrary = {version = "7.3", markers = "platform_release >= \"10.0\""}
+pyobjc-framework-KernelManagement = {version = "7.3", markers = "platform_release >= \"20.0\""}
+pyobjc-framework-LatentSemanticMapping = "7.3"
+pyobjc-framework-LaunchServices = "7.3"
+pyobjc-framework-libdispatch = {version = "7.3", markers = "platform_release >= \"12.0\""}
+pyobjc-framework-LinkPresentation = {version = "7.3", markers = "platform_release >= \"19.0\""}
+pyobjc-framework-LocalAuthentication = {version = "7.3", markers = "platform_release >= \"14.0\""}
+pyobjc-framework-MapKit = {version = "7.3", markers = "platform_release >= \"13.0\""}
+pyobjc-framework-MediaAccessibility = {version = "7.3", markers = "platform_release >= \"13.0\""}
+pyobjc-framework-MediaLibrary = {version = "7.3", markers = "platform_release >= \"13.0\""}
+pyobjc-framework-MediaPlayer = {version = "7.3", markers = "platform_release >= \"16.0\""}
+pyobjc-framework-MediaToolbox = {version = "7.3", markers = "platform_release >= \"13.0\""}
+pyobjc-framework-Message = {version = "7.3", markers = "platform_release < \"13.0\""}
+pyobjc-framework-Metal = {version = "7.3", markers = "platform_release >= \"15.0\""}
+pyobjc-framework-MetalKit = {version = "7.3", markers = "platform_release >= \"15.0\""}
+pyobjc-framework-MetalPerformanceShaders = {version = "7.3", markers = "platform_release >= \"17.0\""}
+pyobjc-framework-MetalPerformanceShadersGraph = {version = "7.3", markers = "platform_release >= \"20.0\""}
+pyobjc-framework-MLCompute = {version = "7.3", markers = "platform_release >= \"20.0\""}
+pyobjc-framework-ModelIO = {version = "7.3", markers = "platform_release >= \"15.0\""}
+pyobjc-framework-MultipeerConnectivity = {version = "7.3", markers = "platform_release >= \"14.0\""}
+pyobjc-framework-NaturalLanguage = {version = "7.3", markers = "platform_release >= \"18.0\""}
+pyobjc-framework-NetFS = {version = "7.3", markers = "platform_release >= \"10.0\""}
+pyobjc-framework-Network = {version = "7.3", markers = "platform_release >= \"18.0\""}
+pyobjc-framework-NetworkExtension = {version = "7.3", markers = "platform_release >= \"15.0\""}
+pyobjc-framework-NotificationCenter = {version = "7.3", markers = "platform_release >= \"14.0\""}
+pyobjc-framework-OpenDirectory = {version = "7.3", markers = "platform_release >= \"10.0\""}
+pyobjc-framework-OSAKit = "7.3"
+pyobjc-framework-OSLog = {version = "7.3", markers = "platform_release >= \"19.0\""}
+pyobjc-framework-PassKit = {version = "7.3", markers = "platform_release >= \"20.0\""}
+pyobjc-framework-PencilKit = {version = "7.3", markers = "platform_release >= \"19.0\""}
+pyobjc-framework-Photos = {version = "7.3", markers = "platform_release >= \"15.0\""}
+pyobjc-framework-PhotosUI = {version = "7.3", markers = "platform_release >= \"15.0\""}
+pyobjc-framework-PreferencePanes = "7.3"
+pyobjc-framework-PubSub = {version = "7.3", markers = "platform_release >= \"9.0\" and platform_release < \"18.0\""}
+pyobjc-framework-PushKit = {version = "7.3", markers = "platform_release >= \"19.0\""}
+pyobjc-framework-Quartz = "7.3"
+pyobjc-framework-QuickLookThumbnailing = {version = "7.3", markers = "platform_release >= \"19.0\""}
+pyobjc-framework-ReplayKit = {version = "7.3", markers = "platform_release >= \"20.0\""}
+pyobjc-framework-SafariServices = {version = "7.3", markers = "platform_release >= \"15.0\""}
+pyobjc-framework-SceneKit = {version = "7.3", markers = "platform_release >= \"11.0\""}
+pyobjc-framework-ScreenSaver = "7.3"
+pyobjc-framework-ScreenTime = {version = "7.3", markers = "platform_release >= \"20.0\""}
+pyobjc-framework-ScriptingBridge = {version = "7.3", markers = "platform_release >= \"9.0\""}
+pyobjc-framework-SearchKit = "7.3"
+pyobjc-framework-Security = "7.3"
+pyobjc-framework-SecurityFoundation = "7.3"
+pyobjc-framework-SecurityInterface = "7.3"
+pyobjc-framework-ServerNotification = {version = "7.3", markers = "platform_release >= \"10.0\" and platform_release < \"13.0\""}
+pyobjc-framework-ServiceManagement = {version = "7.3", markers = "platform_release >= \"10.0\""}
+pyobjc-framework-Social = {version = "7.3", markers = "platform_release >= \"12.0\""}
+pyobjc-framework-SoundAnalysis = {version = "7.3", markers = "platform_release >= \"19.0\""}
+pyobjc-framework-Speech = {version = "7.3", markers = "platform_release >= \"19.0\""}
+pyobjc-framework-SpriteKit = {version = "7.3", markers = "platform_release >= \"13.0\""}
+pyobjc-framework-StoreKit = {version = "7.3", markers = "platform_release >= \"11.0\""}
+pyobjc-framework-SyncServices = "7.3"
+pyobjc-framework-SystemConfiguration = "7.3"
+pyobjc-framework-SystemExtensions = {version = "7.3", markers = "platform_release >= \"19.0\""}
+pyobjc-framework-UniformTypeIdentifiers = {version = "7.3", markers = "platform_release >= \"20.0\""}
+pyobjc-framework-UserNotifications = {version = "7.3", markers = "platform_release >= \"18.0\""}
+pyobjc-framework-UserNotificationsUI = {version = "7.3", markers = "platform_release >= \"20.0\""}
+pyobjc-framework-VideoSubscriberAccount = {version = "7.3", markers = "platform_release >= \"18.0\""}
+pyobjc-framework-VideoToolbox = {version = "7.3", markers = "platform_release >= \"12.0\""}
+pyobjc-framework-Virtualization = {version = "7.3", markers = "platform_release >= \"20.0\""}
+pyobjc-framework-Vision = {version = "7.3", markers = "platform_release >= \"17.0\""}
+pyobjc-framework-WebKit = "7.3"
+
+[[package]]
+name = "pyobjc-core"
+version = "7.3"
+description = "Python<->ObjC Interoperability Module"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
+name = "pyobjc-framework-accessibility"
+version = "7.3"
+description = "Wrappers for the framework Accessibility on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-framework-Quartz = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-accounts"
+version = "7.3"
+description = "Wrappers for the framework Accounts on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-addressbook"
+version = "7.3"
+description = "Wrappers for the framework AddressBook on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-adservices"
+version = "7.3"
+description = "Wrappers for the framework AdServices on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-adsupport"
+version = "7.3"
+description = "Wrappers for the framework AdSupport on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-applescriptkit"
+version = "7.3"
+description = "Wrappers for the framework AppleScriptKit on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-applescriptobjc"
+version = "7.3"
+description = "Wrappers for the framework AppleScriptObjC on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-applicationservices"
+version = "7.3"
+description = "Wrappers for the framework ApplicationServices on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-framework-Quartz = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-apptrackingtransparency"
+version = "7.3"
+description = "Wrappers for the framework AppTrackingTransparency on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-authenticationservices"
+version = "7.3"
+description = "Wrappers for the framework AuthenticationServices on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-automaticassessmentconfiguration"
+version = "7.3"
+description = "Wrappers for the framework AutomaticAssessmentConfiguration on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-automator"
+version = "7.3"
+description = "Wrappers for the framework Automator on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-avfoundation"
+version = "7.3"
+description = "Wrappers for the framework AVFoundation on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-framework-CoreMedia = ">=7.3"
+pyobjc-framework-Quartz = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-avkit"
+version = "7.3"
+description = "Wrappers for the framework AVKit on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-framework-Quartz = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-businesschat"
+version = "7.3"
+description = "Wrappers for the framework BusinessChat on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-calendarstore"
+version = "7.3"
+description = "Wrappers for the framework CalendarStore on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-callkit"
+version = "7.3"
+description = "Wrappers for the framework CallKit on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-cfnetwork"
+version = "7.3"
+description = "Wrappers for the framework CFNetwork on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-classkit"
+version = "7.3"
+description = "Wrappers for the framework ClassKit on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-cloudkit"
+version = "7.3"
+description = "Wrappers for the framework CloudKit on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Accounts = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-framework-CoreData = ">=7.3"
+pyobjc-framework-CoreLocation = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-cocoa"
+version = "7.3"
+description = "Wrappers for the Cocoa frameworks on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-collaboration"
+version = "7.3"
+description = "Wrappers for the framework Collaboration on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-colorsync"
+version = "7.3"
+description = "Wrappers for the framework ColorSync on Mac OS X"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-contacts"
+version = "7.3"
+description = "Wrappers for the framework Contacts on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-contactsui"
+version = "7.3"
+description = "Wrappers for the framework ContactsUI on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-framework-Contacts = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-coreaudio"
+version = "7.3"
+description = "Wrappers for the framework CoreAudio on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-coreaudiokit"
+version = "7.3"
+description = "Wrappers for the framework CoreAudioKit on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-framework-CoreAudio = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-corebluetooth"
+version = "7.3"
+description = "Wrappers for the framework CoreBluetooth on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-coredata"
+version = "7.3"
+description = "Wrappers for the framework CoreData on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-corehaptics"
+version = "7.3"
+description = "Wrappers for the framework CoreHaptics on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-corelocation"
+version = "7.3"
+description = "Wrappers for the framework CoreLocation on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-coremedia"
+version = "7.3"
+description = "Wrappers for the framework CoreMedia on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-coremediaio"
+version = "7.3"
+description = "Wrappers for the framework CoreMediaIO on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-coremidi"
+version = "7.3"
+description = "Wrappers for the framework CoreMIDI on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-coreml"
+version = "7.3"
+description = "Wrappers for the framework CoreML on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-coremotion"
+version = "7.3"
+description = "Wrappers for the framework CoreMotion on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-coreservices"
+version = "7.3"
+description = "Wrappers for the framework CoreServices on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-FSEvents = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-corespotlight"
+version = "7.3"
+description = "Wrappers for the framework CoreSpotlight on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-coretext"
+version = "7.3"
+description = "Wrappers for the framework CoreText on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-framework-Quartz = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-corewlan"
+version = "7.3"
+description = "Wrappers for the framework CoreWLAN on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-cryptotokenkit"
+version = "7.3"
+description = "Wrappers for the framework CryptoTokenKit on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-devicecheck"
+version = "7.3"
+description = "Wrappers for the framework DeviceCheck on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-dictionaryservices"
+version = "7.3"
+description = "Wrappers for the framework DictionaryServices on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-CoreServices = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-discrecording"
+version = "7.3"
+description = "Wrappers for the framework DiscRecording on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-discrecordingui"
+version = "7.3"
+description = "Wrappers for the framework DiscRecordingUI on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-framework-DiscRecording = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-diskarbitration"
+version = "7.3"
+description = "Wrappers for the framework DiskArbitration on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-dvdplayback"
+version = "7.3"
+description = "Wrappers for the framework DVDPlayback on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-eventkit"
+version = "7.3"
+description = "Wrappers for the framework Accounts on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-exceptionhandling"
+version = "7.3"
+description = "Wrappers for the framework ExceptionHandling on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-executionpolicy"
+version = "7.3"
+description = "Wrappers for the framework ExecutionPolicy on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-externalaccessory"
+version = "7.3"
+description = "Wrappers for the framework ExternalAccessory on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-fileprovider"
+version = "7.3"
+description = "Wrappers for the framework FileProvider on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-fileproviderui"
+version = "7.3"
+description = "Wrappers for the framework FileProviderUI on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-FileProvider = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-findersync"
+version = "7.3"
+description = "Wrappers for the framework FinderSync on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-fsevents"
+version = "7.3"
+description = "Wrappers for the framework FSEvents on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-gamecenter"
+version = "7.3"
+description = "Wrappers for the framework GameCenter on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-gamecontroller"
+version = "7.3"
+description = "Wrappers for the framework GameController on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-gamekit"
+version = "7.3"
+description = "Wrappers for the framework GameKit on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-framework-Quartz = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-gameplaykit"
+version = "7.3"
+description = "Wrappers for the framework GameplayKit on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-framework-SpriteKit = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-imagecapturecore"
+version = "7.3"
+description = "Wrappers for the framework ImageCaptureCore on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-imserviceplugin"
+version = "7.3"
+description = "Wrappers for the framework IMServicePlugIn on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-inputmethodkit"
+version = "7.3"
+description = "Wrappers for the framework InputMethodKit on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-installerplugins"
+version = "7.3"
+description = "Wrappers for the framework InstallerPlugins on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-instantmessage"
+version = "7.3"
+description = "Wrappers for the framework InstantMessage on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-framework-Quartz = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-intents"
+version = "7.3"
+description = "Wrappers for the framework Intents on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-interfacebuilderkit"
+version = "7.3"
+description = "Wrappers for the framework InterfaceBuilderKit on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-iosurface"
+version = "7.3"
+description = "Wrappers for the framework IOSurface on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-ituneslibrary"
+version = "7.3"
+description = "Wrappers for the framework iTunesLibrary on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-kernelmanagement"
+version = "7.3"
+description = "Wrappers for the framework KernelManagement on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-latentsemanticmapping"
+version = "7.3"
+description = "Wrappers for the framework LatentSemanticMapping on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-launchservices"
+version = "7.3"
+description = "Wrappers for the framework LaunchServices on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-CoreServices = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-libdispatch"
+version = "7.3"
+description = "Wrappers for libdispatch on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-linkpresentation"
+version = "7.3"
+description = "Wrappers for the framework LinkPresentation on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-framework-Quartz = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-localauthentication"
+version = "7.3"
+description = "Wrappers for the framework LocalAuthentication on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-framework-Security = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-mapkit"
+version = "7.3"
+description = "Wrappers for the framework MapKit on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-framework-CoreLocation = ">=7.3"
+pyobjc-framework-Quartz = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-mediaaccessibility"
+version = "7.3"
+description = "Wrappers for the framework MediaAccessibility on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-medialibrary"
+version = "7.3"
+description = "Wrappers for the framework MediaLibrary on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-framework-Quartz = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-mediaplayer"
+version = "7.3"
+description = "Wrappers for the framework MediaPlayer on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-AVFoundation = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-mediatoolbox"
+version = "7.3"
+description = "Wrappers for the framework MediaToolbox on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-message"
+version = "7.3"
+description = "Wrappers for the framework Message on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-metal"
+version = "7.3"
+description = "Wrappers for the framework Metal on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-metalkit"
+version = "7.3"
+description = "Wrappers for the framework MetalKit on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-framework-Metal = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-metalperformanceshaders"
+version = "7.3"
+description = "Wrappers for the framework MetalPerformanceShaders on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Metal = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-metalperformanceshadersgraph"
+version = "7.3"
+description = "Wrappers for the framework MetalPerformanceShadersGraph on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-MetalPerformanceShaders = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-mlcompute"
+version = "7.3"
+description = "Wrappers for the framework MLCompute on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-modelio"
+version = "7.3"
+description = "Wrappers for the framework ModelIO on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-framework-Quartz = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-multipeerconnectivity"
+version = "7.3"
+description = "Wrappers for the framework MultipeerConnectivity on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-naturallanguage"
+version = "7.3"
+description = "Wrappers for the framework NaturalLanguage on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-netfs"
+version = "7.3"
+description = "Wrappers for the framework NetFS on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-network"
+version = "7.3"
+description = "Wrappers for the framework Network on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-networkextension"
+version = "7.3"
+description = "Wrappers for the framework NetworkExtension on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-notificationcenter"
+version = "7.3"
+description = "Wrappers for the framework NotificationCenter on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-opendirectory"
+version = "7.3"
+description = "Wrappers for the framework OpenDirectory on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-osakit"
+version = "7.3"
+description = "Wrappers for the framework OSAKit on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-oslog"
+version = "7.3"
+description = "Wrappers for the framework OSLog on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-framework-CoreMedia = ">=7.3"
+pyobjc-framework-Quartz = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-passkit"
+version = "7.3"
+description = "Wrappers for the framework PassKit on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-pencilkit"
+version = "7.3"
+description = "Wrappers for the framework PencilKit on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-photos"
+version = "7.3"
+description = "Wrappers for the framework Photos on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-photosui"
+version = "7.3"
+description = "Wrappers for the framework PhotosUI on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-preferencepanes"
+version = "7.3"
+description = "Wrappers for the framework PreferencePanes on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-pubsub"
+version = "7.3"
+description = "Wrappers for the framework PubSub on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-pushkit"
+version = "7.3"
+description = "Wrappers for the framework PushKit on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-quartz"
+version = "7.3"
+description = "Wrappers for the Quartz frameworks on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-quicklookthumbnailing"
+version = "7.3"
+description = "Wrappers for the framework QuickLookThumbnailing on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-framework-Quartz = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-replaykit"
+version = "7.3"
+description = "Wrappers for the framework ReplayKit on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-safariservices"
+version = "7.3"
+description = "Wrappers for the framework SafariServices on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-scenekit"
+version = "7.3"
+description = "Wrappers for the framework SceneKit on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-framework-Quartz = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-screensaver"
+version = "7.3"
+description = "Wrappers for the framework ScreenSaver on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-screentime"
+version = "7.3"
+description = "Wrappers for the framework ScreenTime on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-scriptingbridge"
+version = "7.3"
+description = "Wrappers for the framework ScriptingBridge on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-searchkit"
+version = "7.3"
+description = "Wrappers for the framework SearchKit on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-CoreServices = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-security"
+version = "7.3"
+description = "Wrappers for the framework Security on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-securityfoundation"
+version = "7.3"
+description = "Wrappers for the framework SecurityFoundation on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-framework-Security = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-securityinterface"
+version = "7.3"
+description = "Wrappers for the framework SecurityInterface on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-framework-Security = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-servernotification"
+version = "7.3"
+description = "Wrappers for the framework ServerNotification on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-servicemanagement"
+version = "7.3"
+description = "Wrappers for the framework ServiceManagement on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-social"
+version = "7.3"
+description = "Wrappers for the framework Social on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-soundanalysis"
+version = "7.3"
+description = "Wrappers for the framework SoundAnalysis on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-speech"
+version = "7.3"
+description = "Wrappers for the framework Speech on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-spritekit"
+version = "7.3"
+description = "Wrappers for the framework SpriteKit on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-framework-Quartz = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-storekit"
+version = "7.3"
+description = "Wrappers for the framework StoreKit on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-syncservices"
+version = "7.3"
+description = "Wrappers for the framework SyncServices on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-framework-CoreData = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-systemconfiguration"
+version = "7.3"
+description = "Wrappers for the framework SystemConfiguration on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-systemextensions"
+version = "7.3"
+description = "Wrappers for the framework SystemExtensions on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-uniformtypeidentifiers"
+version = "7.3"
+description = "Wrappers for the framework UniformTypeIdentifiers on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-usernotifications"
+version = "7.3"
+description = "Wrappers for the framework UserNotifications on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-usernotificationsui"
+version = "7.3"
+description = "Wrappers for the framework UserNotificationsUI on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-framework-UserNotifications = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-videosubscriberaccount"
+version = "7.3"
+description = "Wrappers for the framework VideoSubscriberAccount on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-videotoolbox"
+version = "7.3"
+description = "Wrappers for the framework VideoToolbox on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-framework-CoreMedia = ">=7.3"
+pyobjc-framework-Quartz = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-virtualization"
+version = "7.3"
+description = "Wrappers for the framework Virtualization on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-vision"
+version = "7.3"
+description = "Wrappers for the framework Vision on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-framework-CoreML = ">=7.3"
+pyobjc-framework-Quartz = ">=7.3"
+
+[[package]]
+name = "pyobjc-framework-webkit"
+version = "7.3"
+description = "Wrappers for the framework WebKit on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+
+[[package]]
+name = "pyperclip"
+version = "1.8.2"
+description = "A cross-platform clipboard module for Python. (Only handles plain text for now.)"
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "pyrect"
+version = "0.1.4"
+description = "PyRect is a simple module with a Rect class for Pygame-like rectangular areas."
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "pyscreeze"
+version = "0.1.28"
+description = "A simple, cross-platform screenshot module for Python 2 and 3."
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "python3-xlib"
+version = "0.15"
+description = "Python3 X Library"
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "pytweening"
+version = "1.0.4"
+description = "A collection of tweening / easing functions."
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "regex"
+version = "2021.9.30"
+description = "Alternative regular expression module, to replace re."
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "rubicon-objc"
+version = "0.4.1"
+description = "A bridge between an Objective C runtime environment and Python."
+category = "main"
+optional = false
+python-versions = ">=3.5"
+
+[[package]]
+name = "toml"
+version = "0.10.2"
+description = "Python Library for Tom's Obvious, Minimal Language"
+category = "dev"
+optional = false
+python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
+
+[[package]]
+name = "tomli"
+version = "1.2.1"
+description = "A lil' TOML parser"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
+name = "typing-extensions"
+version = "3.10.0.2"
+description = "Backported and Experimental Type Hints for Python 3.5+"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[metadata]
+lock-version = "1.1"
+python-versions = ">=3.9,<3.11"
+content-hash = "bbb46c1ec95c9e96363c7b864c360d5e35fb72b2bcbca1d67f7a530b92036851"
+
+[metadata.files]
+black = [
+    {file = "black-21.9b0-py3-none-any.whl", hash = "sha256:380f1b5da05e5a1429225676655dddb96f5ae8c75bdf91e53d798871b902a115"},
+    {file = "black-21.9b0.tar.gz", hash = "sha256:7de4cfc7eb6b710de325712d40125689101d21d25283eed7e9998722cf10eb91"},
+]
+click = [
+    {file = "click-8.0.1-py3-none-any.whl", hash = "sha256:fba402a4a47334742d782209a7c79bc448911afe1149d07bdabdf480b3e2f4b6"},
+    {file = "click-8.0.1.tar.gz", hash = "sha256:8c04c11192119b1ef78ea049e0a6f0463e4c48ef00a30160c704337586f3ad7a"},
+]
+colorama = [
+    {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},
+    {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
+]
+flake8 = [
+    {file = "flake8-3.9.2-py2.py3-none-any.whl", hash = "sha256:bf8fd333346d844f616e8d47905ef3a3384edae6b4e9beb0c5101e25e3110907"},
+    {file = "flake8-3.9.2.tar.gz", hash = "sha256:07528381786f2a6237b061f6e96610a4167b226cb926e2aa2b6b1d78057c576b"},
+]
+imutils = [
+    {file = "imutils-0.5.4.tar.gz", hash = "sha256:03827a9fca8b5c540305c0844a62591cf35a0caec199cb0f2f0a4a0fb15d8f24"},
+]
+isort = [
+    {file = "isort-5.9.3-py3-none-any.whl", hash = "sha256:e17d6e2b81095c9db0a03a8025a957f334d6ea30b26f9ec70805411e5c7c81f2"},
+    {file = "isort-5.9.3.tar.gz", hash = "sha256:9c2ea1e62d871267b78307fe511c0838ba0da28698c5732d54e2790bf3ba9899"},
+]
+mccabe = [
+    {file = "mccabe-0.6.1-py2.py3-none-any.whl", hash = "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42"},
+    {file = "mccabe-0.6.1.tar.gz", hash = "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"},
+]
+mouseinfo = [
+    {file = "MouseInfo-0.1.3.tar.gz", hash = "sha256:2c62fb8885062b8e520a3cce0a297c657adcc08c60952eb05bc8256ef6f7f6e7"},
+]
+mypy = [
+    {file = "mypy-0.910-cp35-cp35m-macosx_10_9_x86_64.whl", hash = "sha256:a155d80ea6cee511a3694b108c4494a39f42de11ee4e61e72bc424c490e46457"},
+    {file = "mypy-0.910-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:b94e4b785e304a04ea0828759172a15add27088520dc7e49ceade7834275bedb"},
+    {file = "mypy-0.910-cp35-cp35m-manylinux2010_x86_64.whl", hash = "sha256:088cd9c7904b4ad80bec811053272986611b84221835e079be5bcad029e79dd9"},
+    {file = "mypy-0.910-cp35-cp35m-win_amd64.whl", hash = "sha256:adaeee09bfde366d2c13fe6093a7df5df83c9a2ba98638c7d76b010694db760e"},
+    {file = "mypy-0.910-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:ecd2c3fe726758037234c93df7e98deb257fd15c24c9180dacf1ef829da5f921"},
+    {file = "mypy-0.910-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:d9dd839eb0dc1bbe866a288ba3c1afc33a202015d2ad83b31e875b5905a079b6"},
+    {file = "mypy-0.910-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:3e382b29f8e0ccf19a2df2b29a167591245df90c0b5a2542249873b5c1d78212"},
+    {file = "mypy-0.910-cp36-cp36m-win_amd64.whl", hash = "sha256:53fd2eb27a8ee2892614370896956af2ff61254c275aaee4c230ae771cadd885"},
+    {file = "mypy-0.910-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:b6fb13123aeef4a3abbcfd7e71773ff3ff1526a7d3dc538f3929a49b42be03f0"},
+    {file = "mypy-0.910-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:e4dab234478e3bd3ce83bac4193b2ecd9cf94e720ddd95ce69840273bf44f6de"},
+    {file = "mypy-0.910-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:7df1ead20c81371ccd6091fa3e2878559b5c4d4caadaf1a484cf88d93ca06703"},
+    {file = "mypy-0.910-cp37-cp37m-win_amd64.whl", hash = "sha256:0aadfb2d3935988ec3815952e44058a3100499f5be5b28c34ac9d79f002a4a9a"},
+    {file = "mypy-0.910-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:ec4e0cd079db280b6bdabdc807047ff3e199f334050db5cbb91ba3e959a67504"},
+    {file = "mypy-0.910-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:119bed3832d961f3a880787bf621634ba042cb8dc850a7429f643508eeac97b9"},
+    {file = "mypy-0.910-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:866c41f28cee548475f146aa4d39a51cf3b6a84246969f3759cb3e9c742fc072"},
+    {file = "mypy-0.910-cp38-cp38-win_amd64.whl", hash = "sha256:ceb6e0a6e27fb364fb3853389607cf7eb3a126ad335790fa1e14ed02fba50811"},
+    {file = "mypy-0.910-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:1a85e280d4d217150ce8cb1a6dddffd14e753a4e0c3cf90baabb32cefa41b59e"},
+    {file = "mypy-0.910-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:42c266ced41b65ed40a282c575705325fa7991af370036d3f134518336636f5b"},
+    {file = "mypy-0.910-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:3c4b8ca36877fc75339253721f69603a9c7fdb5d4d5a95a1a1b899d8b86a4de2"},
+    {file = "mypy-0.910-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:c0df2d30ed496a08de5daed2a9ea807d07c21ae0ab23acf541ab88c24b26ab97"},
+    {file = "mypy-0.910-cp39-cp39-win_amd64.whl", hash = "sha256:c6c2602dffb74867498f86e6129fd52a2770c48b7cd3ece77ada4fa38f94eba8"},
+    {file = "mypy-0.910-py3-none-any.whl", hash = "sha256:ef565033fa5a958e62796867b1df10c40263ea9ded87164d67572834e57a174d"},
+    {file = "mypy-0.910.tar.gz", hash = "sha256:704098302473cb31a218f1775a873b376b30b4c18229421e9e9dc8916fd16150"},
+]
+mypy-extensions = [
+    {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
+    {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
+]
+numpy = [
+    {file = "numpy-1.21.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:52a664323273c08f3b473548bf87c8145b7513afd63e4ebba8496ecd3853df13"},
+    {file = "numpy-1.21.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:51a7b9db0a2941434cd930dacaafe0fc9da8f3d6157f9d12f761bbde93f46218"},
+    {file = "numpy-1.21.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:9f2dc79c093f6c5113718d3d90c283f11463d77daa4e83aeeac088ec6a0bda52"},
+    {file = "numpy-1.21.2-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:a55e4d81c4260386f71d22294795c87609164e22b28ba0d435850fbdf82fc0c5"},
+    {file = "numpy-1.21.2-cp37-cp37m-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:426a00b68b0d21f2deb2ace3c6d677e611ad5a612d2c76494e24a562a930c254"},
+    {file = "numpy-1.21.2-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:298156f4d3d46815eaf0fcf0a03f9625fc7631692bd1ad851517ab93c3168fc6"},
+    {file = "numpy-1.21.2-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:09858463db6dd9f78b2a1a05c93f3b33d4f65975771e90d2cf7aadb7c2f66edf"},
+    {file = "numpy-1.21.2-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:805459ad8baaf815883d0d6f86e45b3b0b67d823a8f3fa39b1ed9c45eaf5edf1"},
+    {file = "numpy-1.21.2-cp37-cp37m-win32.whl", hash = "sha256:f545c082eeb09ae678dd451a1b1dbf17babd8a0d7adea02897a76e639afca310"},
+    {file = "numpy-1.21.2-cp37-cp37m-win_amd64.whl", hash = "sha256:b160b9a99ecc6559d9e6d461b95c8eec21461b332f80267ad2c10394b9503496"},
+    {file = "numpy-1.21.2-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:a5109345f5ce7ddb3840f5970de71c34a0ff7fceb133c9441283bb8250f532a3"},
+    {file = "numpy-1.21.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:209666ce9d4a817e8a4597cd475b71b4878a85fa4b8db41d79fdb4fdee01dde2"},
+    {file = "numpy-1.21.2-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:c01b59b33c7c3ba90744f2c695be571a3bd40ab2ba7f3d169ffa6db3cfba614f"},
+    {file = "numpy-1.21.2-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:e42029e184008a5fd3d819323345e25e2337b0ac7f5c135b7623308530209d57"},
+    {file = "numpy-1.21.2-cp38-cp38-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:7fdc7689daf3b845934d67cb221ba8d250fdca20ac0334fea32f7091b93f00d3"},
+    {file = "numpy-1.21.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:550564024dc5ceee9421a86fc0fb378aa9d222d4d0f858f6669eff7410c89bef"},
+    {file = "numpy-1.21.2-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:bf75d5825ef47aa51d669b03ce635ecb84d69311e05eccea083f31c7570c9931"},
+    {file = "numpy-1.21.2-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:a9da45b748caad72ea4a4ed57e9cd382089f33c5ec330a804eb420a496fa760f"},
+    {file = "numpy-1.21.2-cp38-cp38-win32.whl", hash = "sha256:e167b9805de54367dcb2043519382be541117503ce99e3291cc9b41ca0a83557"},
+    {file = "numpy-1.21.2-cp38-cp38-win_amd64.whl", hash = "sha256:466e682264b14982012887e90346d33435c984b7fead7b85e634903795c8fdb0"},
+    {file = "numpy-1.21.2-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:dd0e3651d210068d13e18503d75aaa45656eef51ef0b261f891788589db2cc38"},
+    {file = "numpy-1.21.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:92a0ab128b07799dd5b9077a9af075a63467d03ebac6f8a93e6440abfea4120d"},
+    {file = "numpy-1.21.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:fde50062d67d805bc96f1a9ecc0d37bfc2a8f02b937d2c50824d186aa91f2419"},
+    {file = "numpy-1.21.2-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:640c1ccfd56724f2955c237b6ccce2e5b8607c3bc1cc51d3933b8c48d1da3723"},
+    {file = "numpy-1.21.2-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:5de64950137f3a50b76ce93556db392e8f1f954c2d8207f78a92d1f79aa9f737"},
+    {file = "numpy-1.21.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b342064e647d099ca765f19672696ad50c953cac95b566af1492fd142283580f"},
+    {file = "numpy-1.21.2-cp39-cp39-win32.whl", hash = "sha256:30fc68307c0155d2a75ad19844224be0f2c6f06572d958db4e2053f816b859ad"},
+    {file = "numpy-1.21.2-cp39-cp39-win_amd64.whl", hash = "sha256:b5e8590b9245803c849e09bae070a8e1ff444f45e3f0bed558dd722119eea724"},
+    {file = "numpy-1.21.2-pp37-pypy37_pp73-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:d96a6a7d74af56feb11e9a443150216578ea07b7450f7c05df40eec90af7f4a7"},
+    {file = "numpy-1.21.2.zip", hash = "sha256:423216d8afc5923b15df86037c6053bf030d15cc9e3224206ef868c2d63dd6dc"},
+]
+opencv-python = [
+    {file = "opencv-python-4.5.3.56.tar.gz", hash = "sha256:3c001d3feec7f3140f1fb78dfc52ca28122db8240826882d175a208a89d2731b"},
+    {file = "opencv_python-4.5.3.56-cp36-cp36m-macosx_10_15_x86_64.whl", hash = "sha256:9a78558b5ae848386edbb843c761e5fed5a8480be9af16274a5a78838529edeb"},
+    {file = "opencv_python-4.5.3.56-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:8d3282138f3a8646941089aae142684910ebe40776266448eab5f4bb609fc63f"},
+    {file = "opencv_python-4.5.3.56-cp36-cp36m-manylinux2014_x86_64.whl", hash = "sha256:881f3d85269500e0c7d72b140a6ebb5c14a089f8140fb9da7ce01f12a245858e"},
+    {file = "opencv_python-4.5.3.56-cp36-cp36m-win32.whl", hash = "sha256:f1bda4d144f5204e077ca4571453ebb2015e5748d5e0043386c92c2bbf7f52eb"},
+    {file = "opencv_python-4.5.3.56-cp36-cp36m-win_amd64.whl", hash = "sha256:6763729fcfee2a08e069aa1982c9a8c1abf55b9cdf2fb9640eda1d85bdece19a"},
+    {file = "opencv_python-4.5.3.56-cp37-cp37m-macosx_10_15_x86_64.whl", hash = "sha256:68813b720b88e4951e84399b9a8a7b532d45a07a96ea8f539636242f862e32e0"},
+    {file = "opencv_python-4.5.3.56-cp37-cp37m-macosx_11_0_arm64.whl", hash = "sha256:c360cb76ad1ddbd5d2d3e730b42f2ff6e4be08ea6f4a6eefacca175d27467e8f"},
+    {file = "opencv_python-4.5.3.56-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:437f30e300725e1d1b3744dbfbc66a523a4744792b58f3dbe1e9140c8f4dfba5"},
+    {file = "opencv_python-4.5.3.56-cp37-cp37m-manylinux2014_x86_64.whl", hash = "sha256:e42c644a70d5c54f53a4b114dbd88b4eb83f42a9ca998f07bd5682f3f404efcc"},
+    {file = "opencv_python-4.5.3.56-cp37-cp37m-win32.whl", hash = "sha256:f3ac2355217114a683f3f72a9c40a5890914a59c4a2df62e4083c66ff65c9cf9"},
+    {file = "opencv_python-4.5.3.56-cp37-cp37m-win_amd64.whl", hash = "sha256:7f41b97d84ac66bdf13cb4d9f4dad3e159525ba1e3f421e670c787ce536eb70a"},
+    {file = "opencv_python-4.5.3.56-cp38-cp38-macosx_10_15_x86_64.whl", hash = "sha256:cdc3363c2911d7cfc6c9f55308c51c2841a7aecbf0bf5e791499d220ce89d880"},
+    {file = "opencv_python-4.5.3.56-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:18a4a14015eee30d9cd514db8cdefbf594b1d5c234762d27abe512d62a333bc3"},
+    {file = "opencv_python-4.5.3.56-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:05c5139d620e8d02f7ce0921796d55736fa19fa15e2ec00a388db2eb1ae1e9a1"},
+    {file = "opencv_python-4.5.3.56-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:831b92fe63ce18dd628f71104da7e60596658b75e2fa16b83aefa3eb10c115e2"},
+    {file = "opencv_python-4.5.3.56-cp38-cp38-win32.whl", hash = "sha256:e1f54736272830a1e895cedf7a4ee67737e31e966d380c82a81ef22515d043a3"},
+    {file = "opencv_python-4.5.3.56-cp38-cp38-win_amd64.whl", hash = "sha256:b42bbba9f5421865377c7960bd4f3dd881003b322a6bf46ed2302b89224d102b"},
+    {file = "opencv_python-4.5.3.56-cp39-cp39-macosx_10_15_x86_64.whl", hash = "sha256:5366fcd6eae4243add3c8c92142045850f1db8e464bcf0b75313e1596b2e3671"},
+    {file = "opencv_python-4.5.3.56-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:54c64e86a087841869901fd34462bb6bec01cd4652800fdf5d92fe7b0596c82f"},
+    {file = "opencv_python-4.5.3.56-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:8852be06c0749fef0d9c58f532bbcb0570968c59e41cf56b90f5c92593c6e108"},
+    {file = "opencv_python-4.5.3.56-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:8b5bc61be7fc8565140b746288b370a4bfdb4edb9d680b66bb914e7690485db1"},
+    {file = "opencv_python-4.5.3.56-cp39-cp39-win32.whl", hash = "sha256:085232718f28bddd265da480874c37db5c7354cb08f23f4a68a8639b16276a89"},
+    {file = "opencv_python-4.5.3.56-cp39-cp39-win_amd64.whl", hash = "sha256:205a73adb29c37e42475645519e612e843a985475da993d10b4d5daa6afec36a"},
+]
+pathspec = [
+    {file = "pathspec-0.9.0-py2.py3-none-any.whl", hash = "sha256:7d15c4ddb0b5c802d161efc417ec1a2558ea2653c2e8ad9c19098201dc1c993a"},
+    {file = "pathspec-0.9.0.tar.gz", hash = "sha256:e564499435a2673d586f6b2130bb5b95f04a3ba06f81b8f895b651a3c76aabb1"},
+]
+platformdirs = [
+    {file = "platformdirs-2.4.0-py3-none-any.whl", hash = "sha256:8868bbe3c3c80d42f20156f22e7131d2fb321f5bc86a2a345375c6481a67021d"},
+    {file = "platformdirs-2.4.0.tar.gz", hash = "sha256:367a5e80b3d04d2428ffa76d33f124cf11e8fff2acdaa9b43d545f5c7d661ef2"},
+]
+pyautogui = [
+    {file = "PyAutoGUI-0.9.53.tar.gz", hash = "sha256:d31de8f712218d90be7fc98091fce1a12a3e9196e0c814eb9afd73bb2ec97035"},
+]
+pycodestyle = [
+    {file = "pycodestyle-2.7.0-py2.py3-none-any.whl", hash = "sha256:514f76d918fcc0b55c6680472f0a37970994e07bbb80725808c17089be302068"},
+    {file = "pycodestyle-2.7.0.tar.gz", hash = "sha256:c389c1d06bf7904078ca03399a4816f974a1d590090fecea0c63ec26ebaf1cef"},
+]
+pyflakes = [
+    {file = "pyflakes-2.3.1-py2.py3-none-any.whl", hash = "sha256:7893783d01b8a89811dd72d7dfd4d84ff098e5eed95cfa8905b22bbffe52efc3"},
+    {file = "pyflakes-2.3.1.tar.gz", hash = "sha256:f5bc8ecabc05bb9d291eb5203d6810b49040f6ff446a756326104746cc00c1db"},
+]
+pygetwindow = [
+    {file = "PyGetWindow-0.0.9.tar.gz", hash = "sha256:17894355e7d2b305cd832d717708384017c1698a90ce24f6f7fbf0242dd0a688"},
+]
+pymsgbox = [
+    {file = "PyMsgBox-1.0.9.tar.gz", hash = "sha256:2194227de8bff7a3d6da541848705a155dcbb2a06ee120d9f280a1d7f51263ff"},
+]
+pyobjc = [
+    {file = "pyobjc-7.3-py3-none-any.whl", hash = "sha256:8a42710a73e6a7e4c332619aa3ea6d9981edadefafe4492f295c10fb7f14c4d2"},
+    {file = "pyobjc-7.3.tar.gz", hash = "sha256:322b07420f91b2dd7f624823e53046b922cab4aad28baab01a62463728b7e0c5"},
+]
+pyobjc-core = [
+    {file = "pyobjc-core-7.3.tar.gz", hash = "sha256:5081aedf8bb40aac1a8ad95adac9e44e148a882686ded614adf46bb67fd67574"},
+    {file = "pyobjc_core-7.3-1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:a1f1e6b457127cbf2b5bd2b94520a7c89fb590b739911eadb2b0499a3a5b0e6f"},
+    {file = "pyobjc_core-7.3-1-cp38-cp38-macosx_11_0_universal2.whl", hash = "sha256:ed708cc47bae8b711f81f252af09898a5f986c7a38cec5ad5623d571d328bff8"},
+    {file = "pyobjc_core-7.3-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:4e93ad769a20b908778fe950f62a843a6d8f0fa71996e5f3cc9fab5ae7d17771"},
+    {file = "pyobjc_core-7.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:9f63fd37bbf3785af4ddb2f86cad5ca81c62cfc7d1c0099637ca18343c3656c1"},
+    {file = "pyobjc_core-7.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:e9b1311f72f2e170742a7ee3a8149f52c35158dc024a21e88d6f1e52ba5d718b"},
+    {file = "pyobjc_core-7.3-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:8d5e12a0729dfd1d998a861998b422d0a3e41923d75ea229bacf31372c831d7b"},
+    {file = "pyobjc_core-7.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:efdee8c4884405e0c0186c57f87d7bfaa0abc1f50b18e865db3caea3a1f329b9"},
+]
+pyobjc-framework-accessibility = [
+    {file = "pyobjc-framework-Accessibility-7.3.tar.gz", hash = "sha256:75f11e49a5fdb871da7b86f2363aef9d4ce01975549b3ad70d67bdc53c94c365"},
+    {file = "pyobjc_framework_Accessibility-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:d91afc44bff2a29fd33ff1269317e0c8e6413864d1a8a5f5c60d24ca859b8a45"},
+    {file = "pyobjc_framework_Accessibility-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:bc23152da5ddff4c60a316effcdba43ed664db07f7c4713cb7342a5620cfa04d"},
+]
+pyobjc-framework-accounts = [
+    {file = "pyobjc-framework-Accounts-7.3.tar.gz", hash = "sha256:f35634b7f334a2ce11f8838af1045ec4bf0374000c9296a0f7bbf1b315d81afc"},
+    {file = "pyobjc_framework_Accounts-7.3-py2.py3-none-any.whl", hash = "sha256:8c706252c2c01882277555d7e8b53762895dbb41b76501d33ded1c8a16f1902e"},
+]
+pyobjc-framework-addressbook = [
+    {file = "pyobjc-framework-AddressBook-7.3.tar.gz", hash = "sha256:2c5036369ee78b68337c6524b6a35060891f94d5ef24beacd8abb9c034f6f201"},
+    {file = "pyobjc_framework_AddressBook-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:3e84749937c58776d9157aebbe4599c304f8e5f7e8aa31937c25ba5c0704dd81"},
+    {file = "pyobjc_framework_AddressBook-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:bcf0386a2d26069fe49f5ed1364d9d4c67abe5ae338e91255f713c83c253da16"},
+]
+pyobjc-framework-adservices = [
+    {file = "pyobjc-framework-AdServices-7.3.tar.gz", hash = "sha256:2506d71835258bf52605a8e1f93a1f33d6293c3fe864b3eaa020267860125188"},
+    {file = "pyobjc_framework_AdServices-7.3-py2.py3-none-any.whl", hash = "sha256:a17ff248bbe8da5bc0afa63d00dddbb4e7ed09daf417aa66f5d41236d6879234"},
+]
+pyobjc-framework-adsupport = [
+    {file = "pyobjc-framework-AdSupport-7.3.tar.gz", hash = "sha256:c668c66d4ca0565279a2e8d0c496f63110be8dd6b7fc888438aebd7921e9c773"},
+    {file = "pyobjc_framework_AdSupport-7.3-py2.py3-none-any.whl", hash = "sha256:3db51bbd09d0b2c77b810765aa3588ca88e7be5aa2a716697d04fc5bcdca4235"},
+]
+pyobjc-framework-applescriptkit = [
+    {file = "pyobjc-framework-AppleScriptKit-7.3.tar.gz", hash = "sha256:7c9adfc047222ce4c56dab7182b8408da48ec08c03a57463334f2a122a300aaf"},
+    {file = "pyobjc_framework_AppleScriptKit-7.3-py2.py3-none-any.whl", hash = "sha256:2862cc29e5c2141ba8b35ff85508e0f1616572080dc57732f96eb85b3e8c803b"},
+]
+pyobjc-framework-applescriptobjc = [
+    {file = "pyobjc-framework-AppleScriptObjC-7.3.tar.gz", hash = "sha256:ac6dc66ae55c627182c3e873e58ed6ea1aecf4fc837ffc9321b7d70f9514c193"},
+    {file = "pyobjc_framework_AppleScriptObjC-7.3-py2.py3-none-any.whl", hash = "sha256:e3cfe17d43eb4a8a8c07c9a77fadbf16540c189c99351484d6a189564fda3bc4"},
+]
+pyobjc-framework-applicationservices = [
+    {file = "pyobjc-framework-ApplicationServices-7.3.tar.gz", hash = "sha256:1925ac30a817e557d1c08450005103bbf76ebd3ff473631fe9875070377b0b4d"},
+    {file = "pyobjc_framework_ApplicationServices-7.3-1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:484e5b5e9f1757ad7e28799bb5d5d59ce861a3e5449f06fc3a0d05b998e9e6bb"},
+    {file = "pyobjc_framework_ApplicationServices-7.3-1-cp38-cp38-macosx_11_0_universal2.whl", hash = "sha256:ec0c07775ff7034751306fa382117d12ae8e383b696cda1b2815dfd334c36ff7"},
+    {file = "pyobjc_framework_ApplicationServices-7.3-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:daa4a9c51a927630fdd3d3f627e03ebc370aee3c397305db85a0a8ba4c28ae93"},
+    {file = "pyobjc_framework_ApplicationServices-7.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:167aa21ee47b0ee6e4e399915371d183ae84880dc3813c27519e759acb9d20c9"},
+    {file = "pyobjc_framework_ApplicationServices-7.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:7a98f0f1e21465868f9dd32588ae71e5e6a4cb5c434d4158c9e12273fd7b8f27"},
+    {file = "pyobjc_framework_ApplicationServices-7.3-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:2d55796610e6293e83cc40183347e7f75a7c0682775cc19e5986945efa9cac1b"},
+    {file = "pyobjc_framework_ApplicationServices-7.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:afd1ef147447fe7b06a271458eabb37ece6436705abf86265d7fb57310eca45f"},
+]
+pyobjc-framework-apptrackingtransparency = [
+    {file = "pyobjc-framework-AppTrackingTransparency-7.3.tar.gz", hash = "sha256:e29f193ca3b302394d8d1305daf592fefca290e521d6b0150abb83a7e5ac059c"},
+    {file = "pyobjc_framework_AppTrackingTransparency-7.3-py2.py3-none-any.whl", hash = "sha256:3623e3f81b3a1e140e82ba86376d50cf25e781d3eca64b0b63b35a7dc03d0870"},
+]
+pyobjc-framework-authenticationservices = [
+    {file = "pyobjc-framework-AuthenticationServices-7.3.tar.gz", hash = "sha256:610b2e02a6a9027e85bb7f0e232fbfb93348cff2ce3528e4c35bd4834c9ce164"},
+    {file = "pyobjc_framework_AuthenticationServices-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:8b6de4109e7cd825cb1016e5d826af63dd37ed2d0331e8bcad7c7d1f26185a0e"},
+    {file = "pyobjc_framework_AuthenticationServices-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:c238cb2cfe0c8d5d2d606804aba47d9cecb0f78994072ab419bd5ac823bd3e78"},
+]
+pyobjc-framework-automaticassessmentconfiguration = [
+    {file = "pyobjc-framework-AutomaticAssessmentConfiguration-7.3.tar.gz", hash = "sha256:c932b31d3620c391e68a16afad85216cf9cc84e8efd938ff285563236890c09a"},
+    {file = "pyobjc_framework_AutomaticAssessmentConfiguration-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:7a43f01bcf83f0959359394dba4844ac4c1ba4be3ef8599358bb50fb79963c79"},
+    {file = "pyobjc_framework_AutomaticAssessmentConfiguration-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:e31272d8b344f4ce192e99d620d074e554948f8cacb6eaef3514baea6cad8c2c"},
+]
+pyobjc-framework-automator = [
+    {file = "pyobjc-framework-Automator-7.3.tar.gz", hash = "sha256:37b9ba85dcb138fd2e6a0ff373e88dd33cab3a3137b11bf15dfb40c67f4934d0"},
+    {file = "pyobjc_framework_Automator-7.3-py2.py3-none-any.whl", hash = "sha256:c793a740649253c9d1bc70fc757fd95a946004ae386dbf937b9f4290c47b43ac"},
+]
+pyobjc-framework-avfoundation = [
+    {file = "pyobjc-framework-AVFoundation-7.3.tar.gz", hash = "sha256:e187591b31c2b053d65aef8b8e3de3cd9ad53496b1ec9144e712dbfb2cded20b"},
+    {file = "pyobjc_framework_AVFoundation-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:12b642df505240d6bb493cd10ca34e7785782eda6aba7e361cb1128b29866092"},
+    {file = "pyobjc_framework_AVFoundation-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:8b7e0e1413f3e627a4668c738a308b54324a781b437d064733c71713977b299f"},
+]
+pyobjc-framework-avkit = [
+    {file = "pyobjc-framework-AVKit-7.3.tar.gz", hash = "sha256:00aa57ebe7068dccf53e571870bfffe8e9b0857f99f5225795dbe224b412d22f"},
+    {file = "pyobjc_framework_AVKit-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:59030a44d79533c096bbff5dd6a82c51f4c0730878d58d4eb9ec2cb57f828d7f"},
+    {file = "pyobjc_framework_AVKit-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:a07645592759ecc438beb37bc9b6e3c527647423e7327d325f84380e198e34d2"},
+]
+pyobjc-framework-businesschat = [
+    {file = "pyobjc-framework-BusinessChat-7.3.tar.gz", hash = "sha256:d1e3b16fe25deee3ba39fda17948d98c327523914eef7d16e30582f072442b79"},
+    {file = "pyobjc_framework_BusinessChat-7.3-py2.py3-none-any.whl", hash = "sha256:a0a777c1b6404d7e15a8fdc856178be71a6ad89138dba833f76bf267ba83653e"},
+]
+pyobjc-framework-calendarstore = [
+    {file = "pyobjc-framework-CalendarStore-7.3.tar.gz", hash = "sha256:fb19a8bb059fb84505ff427cea69df604ab4755ed3fee08278c7d94c34dc3cf2"},
+    {file = "pyobjc_framework_CalendarStore-7.3-py2.py3-none-any.whl", hash = "sha256:a1371e0e9137c9d566836e63f8a927ad2fd0a2b076c722c8fff6d48a73a94382"},
+]
+pyobjc-framework-callkit = [
+    {file = "pyobjc-framework-CallKit-7.3.tar.gz", hash = "sha256:5167f17b90ac765774213826af6ce025864ea1643c27ff2f91c76201ada886c3"},
+    {file = "pyobjc_framework_CallKit-7.3-py2.py3-none-any.whl", hash = "sha256:b0ba781bdd02966810b7106f889bd5838d60ac4b25df6fe21d08ece4f6503a8c"},
+]
+pyobjc-framework-cfnetwork = [
+    {file = "pyobjc-framework-CFNetwork-7.3.tar.gz", hash = "sha256:50f0041ee9803857a57827e1995794f8824a4bb7c685d736e1337853c64e741d"},
+    {file = "pyobjc_framework_CFNetwork-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:018e4a4eabc58ded583fe8ea250ad0533ed2c57fd8bfa9a658c867b1826867de"},
+    {file = "pyobjc_framework_CFNetwork-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:24392f6505c243eba7bd2399730bfb39631401796f9f82508c726e723016865e"},
+]
+pyobjc-framework-classkit = [
+    {file = "pyobjc-framework-ClassKit-7.3.tar.gz", hash = "sha256:7da8a38f9a939738092145c3455d1e8917b0e98e9140bdd5ac70dec87e7965c7"},
+    {file = "pyobjc_framework_ClassKit-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:e1c014caeb6d675dfe606a6c77ccd93df7ffca3be0fd6697bb86e6703d66717c"},
+    {file = "pyobjc_framework_ClassKit-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:2b3b1d3d1da7f5a752bb7d32a09c283db49e9281f4702517c10bf66b3bf226be"},
+]
+pyobjc-framework-cloudkit = [
+    {file = "pyobjc-framework-CloudKit-7.3.tar.gz", hash = "sha256:76efef08830d83c44bdaa9e20dfc652c065f2f8d6c7d1f10ee8dd29cba301869"},
+    {file = "pyobjc_framework_CloudKit-7.3-py2.py3-none-any.whl", hash = "sha256:137c605a288a14f4b10bd2cce69b6897e5b2978b621e334ca83b407831084700"},
+]
+pyobjc-framework-cocoa = [
+    {file = "pyobjc-framework-Cocoa-7.3.tar.gz", hash = "sha256:b18d05e7a795a3455ad191c3e43d6bfa673c2a4fd480bb1ccf57191051b80b7e"},
+    {file = "pyobjc_framework_Cocoa-7.3-1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:1e31376806e5de883a1d7c7c87d9ff2a8b09fc05d267e0dfce6e42409fb70c67"},
+    {file = "pyobjc_framework_Cocoa-7.3-1-cp38-cp38-macosx_11_0_universal2.whl", hash = "sha256:d999387927284346035cb63ebb51f86331abc41f9376f9a6970e7f18207db392"},
+    {file = "pyobjc_framework_Cocoa-7.3-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:9edffdfa6dd1f71f21b531c3e61fdd3e4d5d3bf6c5a528c98e88828cd60bac11"},
+    {file = "pyobjc_framework_Cocoa-7.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:35a6340437a4e0109a302150b7d1f6baf57004ccf74834f9e6062fcafe2fd8d7"},
+    {file = "pyobjc_framework_Cocoa-7.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:7c3886f2608ab3ed02482f8b2ebf9f782b324c559e84b52cfd92dba8a1109872"},
+    {file = "pyobjc_framework_Cocoa-7.3-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:2e8e7a1a82cca21d9bfac9115baf065305f3da577bf240085964dfb9c9fff337"},
+    {file = "pyobjc_framework_Cocoa-7.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:6c15f43077c9a2ba1853eb402ff7a9515df9e584315bc2fcb779d4c95ef46dc5"},
+]
+pyobjc-framework-collaboration = [
+    {file = "pyobjc-framework-Collaboration-7.3.tar.gz", hash = "sha256:43a1d85e5d418265f18a4c5d77f33eea6d7ad701482a7796f1986e0ef6f39d9d"},
+    {file = "pyobjc_framework_Collaboration-7.3-py2.py3-none-any.whl", hash = "sha256:86724cb8776c5b9045c80307c0a196432515098a9a4a648f7efca0054fdada1b"},
+]
+pyobjc-framework-colorsync = [
+    {file = "pyobjc-framework-ColorSync-7.3.tar.gz", hash = "sha256:7f95964f1290739642da32a40a6668e5b32d1477635435f3b6eb86689751c80f"},
+    {file = "pyobjc_framework_ColorSync-7.3-py2.py3-none-any.whl", hash = "sha256:23cafb502ac251e363f0128ece1d1fe7df92c2e8ca2545cd502c0030e0da36f6"},
+]
+pyobjc-framework-contacts = [
+    {file = "pyobjc-framework-Contacts-7.3.tar.gz", hash = "sha256:912fccc3b44b9d3b53043df433729344a71ff7652bf18d22c8da4d41c11e444e"},
+    {file = "pyobjc_framework_Contacts-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:7ae50f3eb2d241bca80c0ab52a99ce0eda5e29b4f6a1ec1432cd1d24d1df7209"},
+    {file = "pyobjc_framework_Contacts-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:8504649f8fedaf0d319fd0dfe42214ed060299e080fbe8e8c9111168640d6cfd"},
+]
+pyobjc-framework-contactsui = [
+    {file = "pyobjc-framework-ContactsUI-7.3.tar.gz", hash = "sha256:c35b9f10395ef822bcb418541cca4d972fd4f54d064d29b247702e5deee77f0c"},
+    {file = "pyobjc_framework_ContactsUI-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:ee9c704f1738a291c114c72815c17af1a150c6124b84b23fdef7f09e4f6d5d51"},
+    {file = "pyobjc_framework_ContactsUI-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:e623da9b07c03a2869d9d2d921a4debe5649cde41474fbbea57e32641beae8eb"},
+]
+pyobjc-framework-coreaudio = [
+    {file = "pyobjc-framework-CoreAudio-7.3.tar.gz", hash = "sha256:37d161dc459ba309fa5f46655662cd63ff850b5edddde463c58594bdf4b4dee4"},
+    {file = "pyobjc_framework_CoreAudio-7.3-1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:15afd08639ee05b8b2924f63a54bea3e7893eda0efeda0debc94859e88db943a"},
+    {file = "pyobjc_framework_CoreAudio-7.3-1-cp38-cp38-macosx_11_0_universal2.whl", hash = "sha256:2f74767f25a0dfdab0ccaeaac2a971fde1b5d4035d2314a60ed149f9e32b8401"},
+    {file = "pyobjc_framework_CoreAudio-7.3-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:11876f4eb434a492674f8b61a5e9ebd6d9f5bc5ba49a2dd56e5e8dcfee92138f"},
+    {file = "pyobjc_framework_CoreAudio-7.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:b4fec7d9be1c094caefea862782960d7ee4e33526e31896fee5838b8fe95d01f"},
+    {file = "pyobjc_framework_CoreAudio-7.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:f2ef8d2b1a2aab20f12fe978adcdcc21f5c83f5c0374e0cc908e13c49d3a2d69"},
+    {file = "pyobjc_framework_CoreAudio-7.3-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:2c6a6641d4c6bf0464db014b9406566cebad86ae59401e356e09552b2cd478fc"},
+    {file = "pyobjc_framework_CoreAudio-7.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:6eb67ccecdf488e9369706727f8b90623dea35159f8193a59c04d2cd4d752067"},
+]
+pyobjc-framework-coreaudiokit = [
+    {file = "pyobjc-framework-CoreAudioKit-7.3.tar.gz", hash = "sha256:9f0ad55dedbff8539c89990a74bb57c452273ac32a5676acbc22becae677b683"},
+    {file = "pyobjc_framework_CoreAudioKit-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:355ac0a26b896c2d024ed8ae92092a17a39b862fc48e58af3f9a27763f8e4a08"},
+    {file = "pyobjc_framework_CoreAudioKit-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:8c8853478f12521750f2c1251c51b5094b8c00970f8337a674f3006fb32e777f"},
+]
+pyobjc-framework-corebluetooth = [
+    {file = "pyobjc-framework-CoreBluetooth-7.3.tar.gz", hash = "sha256:86537978052481023cd378714c5e01a337794435aa1981db60c75517f7dc7fca"},
+    {file = "pyobjc_framework_CoreBluetooth-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:f197fd9c13815c1f41997b7eaadee704a54e9f0bd8a0a2ba75bf549d0889caca"},
+    {file = "pyobjc_framework_CoreBluetooth-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:f9f4e9ce79d1933ca7c046348319ec332bf8e95383bc7af70f26accd9167b5c4"},
+]
+pyobjc-framework-coredata = [
+    {file = "pyobjc-framework-CoreData-7.3.tar.gz", hash = "sha256:e7bb263a38ab0acfb931d8a116bde6d928a17a284d1ffa78eebb2d87f62da9b5"},
+    {file = "pyobjc_framework_CoreData-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:e30504bb316e836b0b7ed49035e4443cd95e04af91745a3f6d5656ccb68c0964"},
+    {file = "pyobjc_framework_CoreData-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:20fd74440c777f57f4f58ea21a8bd14112d853f4b210c1dd6e2c7d0b93d89e1c"},
+]
+pyobjc-framework-corehaptics = [
+    {file = "pyobjc-framework-CoreHaptics-7.3.tar.gz", hash = "sha256:e0ff9800e2ffe93c42583bb4f9cb29ebddd6c36f8c93aa12d5ffcf3ad942d788"},
+    {file = "pyobjc_framework_CoreHaptics-7.3-py2.py3-none-any.whl", hash = "sha256:8263ce87459038e4e6c648dcd127abb55811dd532abfa1d3526f12f52defbc64"},
+]
+pyobjc-framework-corelocation = [
+    {file = "pyobjc-framework-CoreLocation-7.3.tar.gz", hash = "sha256:30060bf97e6cd858192e3cf6ad2725496838062b1750392d6f3c227a8b39bdf8"},
+    {file = "pyobjc_framework_CoreLocation-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:489df752c94d2e51af4881d0a1a5d87ebc1561df17d26ba3a9b177caf90f824d"},
+    {file = "pyobjc_framework_CoreLocation-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:f537af08363281b12ecf1aeed77a2928474a978209ee827cd00d4b3346f411a3"},
+]
+pyobjc-framework-coremedia = [
+    {file = "pyobjc-framework-CoreMedia-7.3.tar.gz", hash = "sha256:c95a09979709241e50a2b000f6772751fed99850f1aaa2cacafd039f3a6b3e99"},
+    {file = "pyobjc_framework_CoreMedia-7.3-1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:f0afa7868bb5225e1acb3c4b5dd2315b866d4b6735f81ef315ac2ca0a985fc0b"},
+    {file = "pyobjc_framework_CoreMedia-7.3-1-cp38-cp38-macosx_11_0_universal2.whl", hash = "sha256:122820c9fc66deda73887c6799c03236fc42fe1445eee6b9c4b28e81d94a3fe7"},
+    {file = "pyobjc_framework_CoreMedia-7.3-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:38a86c24e337b895fa4832323085f2cc84fb5bffaf1c6c4f54173e9774d4017d"},
+    {file = "pyobjc_framework_CoreMedia-7.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:53e874af4c5cedcbb21a52b6482f98afb402798062326efef0f08de37f7af002"},
+    {file = "pyobjc_framework_CoreMedia-7.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:2b911875f1630da6d918c02ca5617e8b5692cc2c8a222874befea19c453fcad7"},
+    {file = "pyobjc_framework_CoreMedia-7.3-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:b6a05656db2dbfb9e27b2a0ee354528a46cf9d2791a398e60db14c93d6f1c089"},
+    {file = "pyobjc_framework_CoreMedia-7.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:089c2cd1eddd9d8a6b3cd624cd44c9f0b222127280d13daacd45ccb0afcda6db"},
+]
+pyobjc-framework-coremediaio = [
+    {file = "pyobjc-framework-CoreMediaIO-7.3.tar.gz", hash = "sha256:4d2b6106456219d8e74a0dcd9fd4ed1c9be50220b559a266f1048bfe0250a5df"},
+    {file = "pyobjc_framework_CoreMediaIO-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:ffa8e5b48bc3b5dfcacd5f8b7f89fe3f02e888f1fcf8597ef41f4767499ee071"},
+    {file = "pyobjc_framework_CoreMediaIO-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:2723c2d994fa1604e2d44719adcc3dda938867aadba565ffecc613b5606e608b"},
+]
+pyobjc-framework-coremidi = [
+    {file = "pyobjc-framework-CoreMIDI-7.3.tar.gz", hash = "sha256:6e333eeddb136579128c8e61476eb638d1db5b7a3bcf2f79ac6f32b00c39ad16"},
+    {file = "pyobjc_framework_CoreMIDI-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:60e99c2a18becad80864801394afc5755c982ebc2877e6c71a95e799de1467be"},
+    {file = "pyobjc_framework_CoreMIDI-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:0ffc7eeb7f3295baa40f477dd2de955dc7b02512ed963dbe6256d0d32250ec16"},
+]
+pyobjc-framework-coreml = [
+    {file = "pyobjc-framework-CoreML-7.3.tar.gz", hash = "sha256:dd6810f920e4b6aba14d3e9a471ea3e6cd36b315e324b76a92c46d7ca8ef7700"},
+    {file = "pyobjc_framework_CoreML-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:3b4e1848fbe7d765946a385dc1bdece6c79aed8f59fd426ecc6a32c1f0d8562d"},
+    {file = "pyobjc_framework_CoreML-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:3f40f91a32769cb9e5550498f95eb272b06a90a0467f528adbf4db9e1273eebb"},
+]
+pyobjc-framework-coremotion = [
+    {file = "pyobjc-framework-CoreMotion-7.3.tar.gz", hash = "sha256:4338c0f24d99d6dac0555a4df1a9265da5164e8603af37eb8345a7e1785624e3"},
+    {file = "pyobjc_framework_CoreMotion-7.3-py2.py3-none-any.whl", hash = "sha256:78afc91a500472ee7a7b9b16a7035aa45ddb83e11339675303d8b86900f3f727"},
+]
+pyobjc-framework-coreservices = [
+    {file = "pyobjc-framework-CoreServices-7.3.tar.gz", hash = "sha256:68240e0314e144e8cccef52c5db112bc4098cb0841c36e747b2f35eeee739e96"},
+    {file = "pyobjc_framework_CoreServices-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:08cac5b662640772e02c8bc62e4a1e21a39794a21826ffe257b48cfe587083f7"},
+    {file = "pyobjc_framework_CoreServices-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:148cc460d9f94ad200d22151c35bf985422790b0cbf1f147f9c1127c5fea23e0"},
+]
+pyobjc-framework-corespotlight = [
+    {file = "pyobjc-framework-CoreSpotlight-7.3.tar.gz", hash = "sha256:5cb0f25f3c48753a355e1f90c7bd94ea5549d03fa33edf92053fb69d8cb0a9de"},
+    {file = "pyobjc_framework_CoreSpotlight-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:0cf4dc2091a75efbdce804a2b3e1e5eb2fe98daaa4ce495f93db47f94ea47eb7"},
+    {file = "pyobjc_framework_CoreSpotlight-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:90a14bd7f1083b9f237d88a22eda22f043f86671416273dc70c73480fe1febc5"},
+]
+pyobjc-framework-coretext = [
+    {file = "pyobjc-framework-CoreText-7.3.tar.gz", hash = "sha256:5b5fc91bcbd2fe5199f6b65971d62bea02f942c76d6acb59168c041c7af435d9"},
+    {file = "pyobjc_framework_CoreText-7.3-1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:ea87b8409d247d0d9968657f36938c62c47369f65ea1094d96b5f6db87c8db0f"},
+    {file = "pyobjc_framework_CoreText-7.3-1-cp38-cp38-macosx_11_0_universal2.whl", hash = "sha256:e1bfadf9e0059c0866c3a4783ab30597aa975dcf5386ba3dfb24d032aa3cf084"},
+    {file = "pyobjc_framework_CoreText-7.3-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:a3ae27d5756b9d62d113e7c4f12022f8812bc95bc277f920f0fe2ca45b5272be"},
+    {file = "pyobjc_framework_CoreText-7.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:fd3f11b3358cbf5a56d4a01e736322daa5b6ce6e3701d41cc9eafcede0267faa"},
+    {file = "pyobjc_framework_CoreText-7.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:d290880894256497425a1abd116076e7a74c8b92a2b1b27d899ede16f52e5f20"},
+    {file = "pyobjc_framework_CoreText-7.3-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:b172b22f51625a0f92c9730b9d9a193f12bd5e56552d77b6841dfaac0d16bab0"},
+    {file = "pyobjc_framework_CoreText-7.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:862e5c2c1bd6f5d276321c9a2d557dd8fb62ab1da55722a582b9e6621b05c1bd"},
+]
+pyobjc-framework-corewlan = [
+    {file = "pyobjc-framework-CoreWLAN-7.3.tar.gz", hash = "sha256:63ab61cd28cd1d61619150e1eff85e3c953f28b4240ec4011229100bb4749657"},
+    {file = "pyobjc_framework_CoreWLAN-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:f102cdc76b1715b85376f80b11d27034458083cd589a161926904dabbe04a41b"},
+    {file = "pyobjc_framework_CoreWLAN-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:8bb19b278c56f9d5dc52ebe7a0f45565a26dcaea24f127e06234c8d75e66a6b1"},
+]
+pyobjc-framework-cryptotokenkit = [
+    {file = "pyobjc-framework-CryptoTokenKit-7.3.tar.gz", hash = "sha256:904ea3ee27135a2fa4b139ed8aed0a50f0c2ce7d3633c7e1e79d317aa5c4e9f8"},
+    {file = "pyobjc_framework_CryptoTokenKit-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:bab35918d7d29bf8264c99b6eba3bfaacaef52f7be28039e8fda955e6b6540f2"},
+    {file = "pyobjc_framework_CryptoTokenKit-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:c2cfbdbb424a8fee16ed76ab558d121e681bb32ea33d4361c5d4fe618ad66c6f"},
+]
+pyobjc-framework-devicecheck = [
+    {file = "pyobjc-framework-DeviceCheck-7.3.tar.gz", hash = "sha256:9f65aa882367a367d8f05bbed52ad822f883970bc0afd7ae0bfb9941e16f13bc"},
+    {file = "pyobjc_framework_DeviceCheck-7.3-py2.py3-none-any.whl", hash = "sha256:12eceb3f9bffa9bdd0a8948bfd9e27ff6be34a8f72a4d72dbe117efbcf13870c"},
+]
+pyobjc-framework-dictionaryservices = [
+    {file = "pyobjc-framework-DictionaryServices-7.3.tar.gz", hash = "sha256:3187b7c24f3fb8e6f5aea89eefacf3657a4bd4fa0f589a69836fb5aeafe2733b"},
+    {file = "pyobjc_framework_DictionaryServices-7.3-py2.py3-none-any.whl", hash = "sha256:c3bc44a4383add1505b348d3a1a99c49708eb8360f44655ba726312d76451421"},
+]
+pyobjc-framework-discrecording = [
+    {file = "pyobjc-framework-DiscRecording-7.3.tar.gz", hash = "sha256:9a1dc83f44227e1522643ec3c0fa774dee9e42b501fce7e1e39ba1e4907e1e22"},
+    {file = "pyobjc_framework_DiscRecording-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:e531c82e35986eb984e2613ef5fc37c1cb0e3b3174c60cbe2e34860052423259"},
+    {file = "pyobjc_framework_DiscRecording-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:690621c0bc25ff2b8c6e227e6294cd9469e8208179d79a7fcf79e580159f582e"},
+]
+pyobjc-framework-discrecordingui = [
+    {file = "pyobjc-framework-DiscRecordingUI-7.3.tar.gz", hash = "sha256:5db083a92bc9513a818d1bc4574a3313f9b967f2aa8dce888ebe436b9a948673"},
+    {file = "pyobjc_framework_DiscRecordingUI-7.3-py2.py3-none-any.whl", hash = "sha256:c30d3000885be80aded9f4517946fed3ab6c43dce89923ad62ebadb7f5135ebc"},
+]
+pyobjc-framework-diskarbitration = [
+    {file = "pyobjc-framework-DiskArbitration-7.3.tar.gz", hash = "sha256:f34d28226760fdce865487b2ea6835e5256f0df00deb68154515e51dc36ea352"},
+    {file = "pyobjc_framework_DiskArbitration-7.3-py2.py3-none-any.whl", hash = "sha256:edac3e6a8daa20cd39d3295b253b0118d6fb1e757357f1fcb384b2abda12cca0"},
+]
+pyobjc-framework-dvdplayback = [
+    {file = "pyobjc-framework-DVDPlayback-7.3.tar.gz", hash = "sha256:4e71fafed5901652ad7540f1f25e9250c5c6522039bf74681e850c6241bfe497"},
+    {file = "pyobjc_framework_DVDPlayback-7.3-py2.py3-none-any.whl", hash = "sha256:523bb58d41b972514187ef0dddadc5033f739074e5a89002d677282575b1e777"},
+]
+pyobjc-framework-eventkit = [
+    {file = "pyobjc-framework-EventKit-7.3.tar.gz", hash = "sha256:826e04c0211c781ce85b4efb0de4b72d833a66e8475e3f1728f318253fd9ffea"},
+    {file = "pyobjc_framework_EventKit-7.3-py2.py3-none-any.whl", hash = "sha256:08034245c385f31d93eddd181f48defefd9f97fcfff7d01ae47dc5dd3aacd424"},
+]
+pyobjc-framework-exceptionhandling = [
+    {file = "pyobjc-framework-ExceptionHandling-7.3.tar.gz", hash = "sha256:1843f8e48d88c8518280c0daf23247a4f12897cb3b7b9b77ee014cf0b4a145bd"},
+    {file = "pyobjc_framework_ExceptionHandling-7.3-py2.py3-none-any.whl", hash = "sha256:f5c04dfb0178c983e60e6a19d1ff75ee74898d79d87916005a562bceb941d469"},
+]
+pyobjc-framework-executionpolicy = [
+    {file = "pyobjc-framework-ExecutionPolicy-7.3.tar.gz", hash = "sha256:27f1bd941320238eaebf933b30b401cf0af5b581af2d4197554ef6977125a2ef"},
+    {file = "pyobjc_framework_ExecutionPolicy-7.3-py2.py3-none-any.whl", hash = "sha256:b042788483b40178bfaabe7bde4a4db76e340877d1525074a2e3812cceafe9d0"},
+]
+pyobjc-framework-externalaccessory = [
+    {file = "pyobjc-framework-ExternalAccessory-7.3.tar.gz", hash = "sha256:74b5c2cce8f2a7a70c2e57e6ecf773ac5e083887e27b5acb86e97eb5c4f1d472"},
+    {file = "pyobjc_framework_ExternalAccessory-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:ff6727bc5b1d2894e7a8e350272a19be6d4b70621a22a488e9efe64971b01086"},
+    {file = "pyobjc_framework_ExternalAccessory-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:b72bf6d62aaefb7ad5a7997b3ef8be4a270861edbb1c4546a82963c3d09ae5a0"},
+]
+pyobjc-framework-fileprovider = [
+    {file = "pyobjc-framework-FileProvider-7.3.tar.gz", hash = "sha256:cec94c9e2eef09e624834a358da7c0827938eb0825c2804b09a2bf20858a6615"},
+    {file = "pyobjc_framework_FileProvider-7.3-1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:ede612a7eaa0bfd39c6e3e68f6d6c7efab3f6f0565f45b90a21f2de7db101d24"},
+    {file = "pyobjc_framework_FileProvider-7.3-1-cp38-cp38-macosx_11_0_universal2.whl", hash = "sha256:393f90a8a3e445aa829d859e7d29322ac82d2a588c731cc7b6b10c4152e7dc84"},
+    {file = "pyobjc_framework_FileProvider-7.3-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:55537492938356fb0d2034327d39e84c46b2e7340b923177ba249baf0ce43b38"},
+    {file = "pyobjc_framework_FileProvider-7.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:a427f2f560b8568f7992467b4f8acde9dd9de716979a71484cea06ad9e3465ef"},
+    {file = "pyobjc_framework_FileProvider-7.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:370dfde069494818f077ff06ee02cdedc9c3733add6df5336800c5f14c6519ff"},
+    {file = "pyobjc_framework_FileProvider-7.3-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:7b3649e1ddfa2c936a27d8d4c811d72786c911809909d0367ca08cae740d81f2"},
+    {file = "pyobjc_framework_FileProvider-7.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:71170dd3fb5b9abfe59bf441568b31b8059284054501419c06c94871006cb5cb"},
+]
+pyobjc-framework-fileproviderui = [
+    {file = "pyobjc-framework-FileProviderUI-7.3.tar.gz", hash = "sha256:2cf6f7182bde330ee018233014549f24ed89002f543364f55ca99fd5ee51051e"},
+    {file = "pyobjc_framework_FileProviderUI-7.3-py2.py3-none-any.whl", hash = "sha256:df4babeb6ca03575f8488a4bd999d6a62b2825706ef8438960fe299938c05d54"},
+]
+pyobjc-framework-findersync = [
+    {file = "pyobjc-framework-FinderSync-7.3.tar.gz", hash = "sha256:f68c6920a1a8445c170dfc6c345243e772e331ff01f5a2eef04b330ab5ae8c42"},
+    {file = "pyobjc_framework_FinderSync-7.3-py2.py3-none-any.whl", hash = "sha256:51ef8c0ae97575a9aa2c5abf9c9739bf40ec2482371fdf40baa13f58ad05fd79"},
+]
+pyobjc-framework-fsevents = [
+    {file = "pyobjc-framework-FSEvents-7.3.tar.gz", hash = "sha256:3d12df35cc0b18c3f7c677d6bc870a7ea13a5d1c2f16456c1f445e0b894ddb55"},
+    {file = "pyobjc_framework_FSEvents-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:65d2fed30225c9de9678f68cf41e56f0e1afaaac6e3ae82075e874e93e42a823"},
+    {file = "pyobjc_framework_FSEvents-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:dc9e2b8ed3dc2f6acffacd52681ece8141711acd5e02d23638f6a48af9bcfc5a"},
+]
+pyobjc-framework-gamecenter = [
+    {file = "pyobjc-framework-GameCenter-7.3.tar.gz", hash = "sha256:1a13c35fa7f109d043e5d0d8cd5f808d061a4ce525580550dceca2697270beaf"},
+    {file = "pyobjc_framework_GameCenter-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:fee0d1bf927daefbf6dea6c980ffc04d54df03041f01e0895999c82be5cb27ea"},
+    {file = "pyobjc_framework_GameCenter-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:5f6a5d673b767372f60603a5f370d46ea3895168dd9efd501bb34d64a66844e9"},
+]
+pyobjc-framework-gamecontroller = [
+    {file = "pyobjc-framework-GameController-7.3.tar.gz", hash = "sha256:745088df9c3d127e0949f5ee19d12c8c88f305c8406769f12da4299338320d91"},
+    {file = "pyobjc_framework_GameController-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:ae38efcce1dcba570fb97a377a2af8372e2dee5129466193b52a7ab3996306aa"},
+    {file = "pyobjc_framework_GameController-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:6d88715544ef6159ba5d10e6e9148cab1d7c94e572ee23e06d8d95262ac05425"},
+]
+pyobjc-framework-gamekit = [
+    {file = "pyobjc-framework-GameKit-7.3.tar.gz", hash = "sha256:6bb7b60b638026c2c5dca0f2ed92e0710e83d7b2ac5393387cbe3b80f1f46c6b"},
+    {file = "pyobjc_framework_GameKit-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:899c5a98d1c86d918c2d4ff2928974d3f177a3bd1db2cdd1362ac1978c7746f9"},
+    {file = "pyobjc_framework_GameKit-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:eac5768f71e8d78edef9ac3d660bb55ccda911e42fd13a5ca157c10342848a5c"},
+]
+pyobjc-framework-gameplaykit = [
+    {file = "pyobjc-framework-GameplayKit-7.3.tar.gz", hash = "sha256:6138e5e7eb16c0f6dc1d9d9d570589f6dd19746be7a5a84ef69f3288e8f87cbb"},
+    {file = "pyobjc_framework_GameplayKit-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:2a93a9eaef10c693c37764d8b73702036f85ad733dfb84b7e2569e1d64efb4be"},
+    {file = "pyobjc_framework_GameplayKit-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:e90fa8213580990ff982664b71fbc414d3015d83b5819c2dbed967dca9352cf7"},
+]
+pyobjc-framework-imagecapturecore = [
+    {file = "pyobjc-framework-ImageCaptureCore-7.3.tar.gz", hash = "sha256:e0143ae9d33d5dae5427b1823444a83f89fbdbcc5f0d42b3c3fe5e6dd17ec4e5"},
+    {file = "pyobjc_framework_ImageCaptureCore-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:a292eddc7db0bb57cd40ac32fe16c85be21e0dbad99f1f414d520456e0ae9f70"},
+    {file = "pyobjc_framework_ImageCaptureCore-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:adc2e0b6ac1a60adc778a56a0f5b6b53631f441f46c592e693c79b64b47bf229"},
+]
+pyobjc-framework-imserviceplugin = [
+    {file = "pyobjc-framework-IMServicePlugIn-7.3.tar.gz", hash = "sha256:04faa56cdf2899bba8d7d397d9cd77a8bf12aa631d979b005365201611a0712f"},
+    {file = "pyobjc_framework_IMServicePlugIn-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:7d41664b7fe6059cf311d589d6b7ab35726b74d7e10fd0d61e270954818c39c6"},
+    {file = "pyobjc_framework_IMServicePlugIn-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:b2b297f68891a3be1120767a6509ec3eba81cf74fc550974362140820c9def82"},
+]
+pyobjc-framework-inputmethodkit = [
+    {file = "pyobjc-framework-InputMethodKit-7.3.tar.gz", hash = "sha256:c96d51bdbdf55c05ca53ed50691c9e7258265c700126f25498f293d708dbb601"},
+    {file = "pyobjc_framework_InputMethodKit-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:fda4b2fc8fa989f5f59fe7abed42d42784a12b5731a93636609bd2d6014715bb"},
+    {file = "pyobjc_framework_InputMethodKit-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:5984ed9239ca8f5e8d29d76cc7a218570f8c6a29b0705b6853fa2eda65e3542e"},
+]
+pyobjc-framework-installerplugins = [
+    {file = "pyobjc-framework-InstallerPlugins-7.3.tar.gz", hash = "sha256:d1bd6b8df714a6f7dd7dc19e5a96c13434732ff6a17dcc3bb21f88ea7cd9cdf2"},
+    {file = "pyobjc_framework_InstallerPlugins-7.3-py2.py3-none-any.whl", hash = "sha256:8b770f0d5633cc04a5aea376766ed5d18aa75806275f3e9579e4b2093c29ca18"},
+]
+pyobjc-framework-instantmessage = [
+    {file = "pyobjc-framework-InstantMessage-7.3.tar.gz", hash = "sha256:dbc907cbdd4ae0766f568c709460381846fb57852496177dafb323960e52f22f"},
+    {file = "pyobjc_framework_InstantMessage-7.3-py2.py3-none-any.whl", hash = "sha256:dfbed891b064bae5fa4cb6c205d9820e49002dac3b49021f526c9d0360c0bd14"},
+]
+pyobjc-framework-intents = [
+    {file = "pyobjc-framework-Intents-7.3.tar.gz", hash = "sha256:1220eeaad2849f7ba75f947c94343087f33495b678bf3bdb695a22ba23520a4d"},
+    {file = "pyobjc_framework_Intents-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:b6ac38cb878cce0caac161e2529ae79c82eac2a658e0323da52df8626fe94cbe"},
+    {file = "pyobjc_framework_Intents-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:e25038fbf70c1b3f55c17067601f28d06745e9fb6874e7a03672c5639ee0fd70"},
+]
+pyobjc-framework-interfacebuilderkit = [
+    {file = "pyobjc-framework-InterfaceBuilderKit-7.3.tar.gz", hash = "sha256:5b6ce97e92cfadff4a95ba87bf6c355026af9698f2aa87fbfa0396286511ab44"},
+    {file = "pyobjc_framework_InterfaceBuilderKit-7.3-py2.py3-none-any.whl", hash = "sha256:7f0c3a1a15e7b818062b814b4e360f30cab2b7500b029107457187e0e2e3424b"},
+]
+pyobjc-framework-iosurface = [
+    {file = "pyobjc-framework-IOSurface-7.3.tar.gz", hash = "sha256:bbaa566eb2972cfd44531875aefb7c0622f31743b4d85bd957348edc7eab21d5"},
+    {file = "pyobjc_framework_IOSurface-7.3-py2.py3-none-any.whl", hash = "sha256:28a02d8ade66ab6c02c64e002c92f4b5ac2b0590d7b0b3a0dcb57d415f44f4a1"},
+]
+pyobjc-framework-ituneslibrary = [
+    {file = "pyobjc-framework-iTunesLibrary-7.3.tar.gz", hash = "sha256:340c5aa952871aa34a7dcad677fb537252d4ecedde499d88f89de0093b117ac3"},
+    {file = "pyobjc_framework_iTunesLibrary-7.3-py2.py3-none-any.whl", hash = "sha256:cac84e32b338fcc68ab80befc51460e9adc5181e19c4d07b319b50dde93c3cbc"},
+]
+pyobjc-framework-kernelmanagement = [
+    {file = "pyobjc-framework-KernelManagement-7.3.tar.gz", hash = "sha256:7f04f73ec4dbaab3402f5c45b716ce35d34a595f9cf87bcb62573ee9beb2a00b"},
+    {file = "pyobjc_framework_KernelManagement-7.3-py2.py3-none-any.whl", hash = "sha256:d5efc836aac83df2f71e3e20f0e5ab877640897f79f81a65bb5e0c9a82023280"},
+]
+pyobjc-framework-latentsemanticmapping = [
+    {file = "pyobjc-framework-LatentSemanticMapping-7.3.tar.gz", hash = "sha256:67abdb884a5114887d10c7528711eef9501843c14188a150c915339d796defd0"},
+    {file = "pyobjc_framework_LatentSemanticMapping-7.3-py2.py3-none-any.whl", hash = "sha256:f252083f5321222726597938685c31e9b53b6e6cd3db9c84a9b54426291bb0c5"},
+]
+pyobjc-framework-launchservices = [
+    {file = "pyobjc-framework-LaunchServices-7.3.tar.gz", hash = "sha256:53cdb7c7566b169c6c373512b8e5a6b3ad8cdf540ad56eb36c9a424e5228fb1b"},
+    {file = "pyobjc_framework_LaunchServices-7.3-py2.py3-none-any.whl", hash = "sha256:95bd4a68f4a5d098e2e4619d7d392753fa0978acba482384aaa441a6c82c4f6d"},
+]
+pyobjc-framework-libdispatch = [
+    {file = "pyobjc-framework-libdispatch-7.3.tar.gz", hash = "sha256:c3e63ce294e50a36c17bc9e65ccf3e448995931fc10fc0c15f899d27c438e25f"},
+    {file = "pyobjc_framework_libdispatch-7.3-1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:e945cda52619d53435fbbdccc63d195987bccfdc6abc59b12caf0c16852d6a45"},
+    {file = "pyobjc_framework_libdispatch-7.3-1-cp38-cp38-macosx_11_0_universal2.whl", hash = "sha256:c03d0885d321c813ce0c3cfda17cb531cd71f005adbfd402275bc4f6ba8d6319"},
+    {file = "pyobjc_framework_libdispatch-7.3-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:2262ab83c6236d168c4e595ecdb1973c1f845dd0dc21840f4a8ce6f900d7e357"},
+    {file = "pyobjc_framework_libdispatch-7.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:57acf9136ad53794c2303dc0f055491270cf70b85f89cef79493c09b60f60f59"},
+    {file = "pyobjc_framework_libdispatch-7.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:be032ce5d05ac23e82c18a6d25459b45ceac3f3073949a439584a99fc26582a5"},
+    {file = "pyobjc_framework_libdispatch-7.3-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:69137492b4564d739f9b4eb56f8823a32fab47d13e809ca401b0c66240be929c"},
+    {file = "pyobjc_framework_libdispatch-7.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:7bc56539ac0761519d6f68149a012ed9b4250781156dbeeeeb8920146125222a"},
+]
+pyobjc-framework-linkpresentation = [
+    {file = "pyobjc-framework-LinkPresentation-7.3.tar.gz", hash = "sha256:ba06355eedbbd83b703171d53d7cda2ff2294c4eb8ececd431a10683bf09bdbe"},
+    {file = "pyobjc_framework_LinkPresentation-7.3-py2.py3-none-any.whl", hash = "sha256:b0c572fab75789b5775d5ce941e4e1a53ebe438846996f148b12e1ba2b585e02"},
+]
+pyobjc-framework-localauthentication = [
+    {file = "pyobjc-framework-LocalAuthentication-7.3.tar.gz", hash = "sha256:0c7ac94f90e3e5e1797980dca08548f5e7ce38ba1578d10b45dd2b611c41183a"},
+    {file = "pyobjc_framework_LocalAuthentication-7.3-py2.py3-none-any.whl", hash = "sha256:3d2c7d7b945ec6b635a61adcb493bc5130abfbb7bbf2dc779ec7b7edba4efc72"},
+]
+pyobjc-framework-mapkit = [
+    {file = "pyobjc-framework-MapKit-7.3.tar.gz", hash = "sha256:efb836c7a9e97c971cec4549043bfdbf4088164f75b177ac3de67a3a98817d2f"},
+    {file = "pyobjc_framework_MapKit-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:8b946a4b204895dd380a09e8bd28f543475714c3a5bf63913cd2436986d07932"},
+    {file = "pyobjc_framework_MapKit-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:0f9a95f2d6edac843de545df8d00280ef222ed8508ef4ee940a34d56d7b11352"},
+]
+pyobjc-framework-mediaaccessibility = [
+    {file = "pyobjc-framework-MediaAccessibility-7.3.tar.gz", hash = "sha256:687403801f89805710c8de0a3a41811614e772776f19c9e041c06eb4fb529c24"},
+    {file = "pyobjc_framework_MediaAccessibility-7.3-py2.py3-none-any.whl", hash = "sha256:91b61f99521fea516affae23b0a208204b3326d5ad90b8cf32dac786287cb84f"},
+]
+pyobjc-framework-medialibrary = [
+    {file = "pyobjc-framework-MediaLibrary-7.3.tar.gz", hash = "sha256:d23b9f80ca63cd8e2471e64794df30231e1b71eb9f0259c986225b1a58face22"},
+    {file = "pyobjc_framework_MediaLibrary-7.3-py2.py3-none-any.whl", hash = "sha256:63449f7109d292c4179f169cb5e9c114141683c2a95ab260f870339f616f38d8"},
+]
+pyobjc-framework-mediaplayer = [
+    {file = "pyobjc-framework-MediaPlayer-7.3.tar.gz", hash = "sha256:76e3746cad7c1f0fa2f08ae3ba922316c634fc85c4c7616b573e79bd781c30be"},
+    {file = "pyobjc_framework_MediaPlayer-7.3-py2.py3-none-any.whl", hash = "sha256:e6133a4cc293b98e6f0c9ffff3aa2becf3cccc6c89b79a04ab976459f62be5dd"},
+]
+pyobjc-framework-mediatoolbox = [
+    {file = "pyobjc-framework-MediaToolbox-7.3.tar.gz", hash = "sha256:52013a09fc7d1cab5613d2044f14016f7b6b504c5ed50cca80894f93de59008e"},
+    {file = "pyobjc_framework_MediaToolbox-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:92ab0d38fb9036499399f27091f123d73f28618a1cda0b2eb6745f798843366b"},
+    {file = "pyobjc_framework_MediaToolbox-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:8a17cdb1a8d69b6104ff901cb335f085f6549b03de30d40fba319bf6ec1b8257"},
+]
+pyobjc-framework-message = [
+    {file = "pyobjc-framework-Message-7.3.tar.gz", hash = "sha256:3a713a19357ebe26b6476489d5ff0c6ef3d9c477c40595d13d218dcf6ea9cc38"},
+    {file = "pyobjc_framework_Message-7.3-py2.py3-none-any.whl", hash = "sha256:c36e2e28e91bce78123ad35dc0e84a841d455b5974cb891fff15accc7c0cb49d"},
+]
+pyobjc-framework-metal = [
+    {file = "pyobjc-framework-Metal-7.3.tar.gz", hash = "sha256:249d996476cee9e8762839b16d6fcfedd4acd3195fe1ef436aa6e3806177db37"},
+    {file = "pyobjc_framework_Metal-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:1ad907a5432809eb807ebda843ed44b07d389d09d0c29a678ac88fee06558d56"},
+    {file = "pyobjc_framework_Metal-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:e69a7780edeab17fee4662e62f0a62c70c613051b27d3ac2813b2fc445ebee38"},
+]
+pyobjc-framework-metalkit = [
+    {file = "pyobjc-framework-MetalKit-7.3.tar.gz", hash = "sha256:a834a881fef2f4986384423a3393ebd934719ca436e2e9df76519ef424162278"},
+    {file = "pyobjc_framework_MetalKit-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:7e6ed417fccd1d2467fa65ebb57770f621cf05ea6075462425de33434a3262e7"},
+    {file = "pyobjc_framework_MetalKit-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:37644b9a27f6ea481eb2d6f1db71b603c49e3789d62fdccb7dfe9c18d4eb84ad"},
+]
+pyobjc-framework-metalperformanceshaders = [
+    {file = "pyobjc-framework-MetalPerformanceShaders-7.3.tar.gz", hash = "sha256:aab31f039b4236a7799cf36ea9343c04065856f0257b874e8bfd653d35069007"},
+    {file = "pyobjc_framework_MetalPerformanceShaders-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:e73270a94b6ae4500eb56d9ce8a7dd0484195314ed96196aaf9c6c23b72b0442"},
+    {file = "pyobjc_framework_MetalPerformanceShaders-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:d1a2d86a679a8db75ca35bd8f614430b7d8aa4de8e73205327abb140da917db2"},
+]
+pyobjc-framework-metalperformanceshadersgraph = [
+    {file = "pyobjc-framework-MetalPerformanceShadersGraph-7.3.tar.gz", hash = "sha256:a81d957f0cfb7901ef6698d892df1432bd9d84bc2ef814319e91faf0663e0586"},
+    {file = "pyobjc_framework_MetalPerformanceShadersGraph-7.3-py2.py3-none-any.whl", hash = "sha256:432f4a542c1037c7fd65041d21d2e51684bea0649b308d0054e45c3d7df4176b"},
+]
+pyobjc-framework-mlcompute = [
+    {file = "pyobjc-framework-MLCompute-7.3.tar.gz", hash = "sha256:113c78b4decb48e6c46a8e8037476b26869a7ac4439ed7e83e5a92224ee39beb"},
+    {file = "pyobjc_framework_MLCompute-7.3-py2.py3-none-any.whl", hash = "sha256:c1d68f402d70751a18cda5d5644cbf808e7b5f38a568002de50cfbbea4604ec3"},
+]
+pyobjc-framework-modelio = [
+    {file = "pyobjc-framework-ModelIO-7.3.tar.gz", hash = "sha256:d151e5888300d533e23939df79be04563925fe9620d2698173b5e05b9e721678"},
+    {file = "pyobjc_framework_ModelIO-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:fae27754371cb8c20939cdf2cbb792aaf995633804d1fb51101f9f8c737c5d10"},
+    {file = "pyobjc_framework_ModelIO-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:095d10162aeb8810576506b02a3891056fdc12d1deac478f57bb633bc4af67bd"},
+]
+pyobjc-framework-multipeerconnectivity = [
+    {file = "pyobjc-framework-MultipeerConnectivity-7.3.tar.gz", hash = "sha256:a5b42dede182ad3e42d0e5bc764d55d3b75741383508f88c914d9559b8a6cfae"},
+    {file = "pyobjc_framework_MultipeerConnectivity-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:e3298250a9ab97cb1dda6010311c4c7aee79ca5642e52025b468608f4b97ce0c"},
+    {file = "pyobjc_framework_MultipeerConnectivity-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:a63ad18c91cde6c447c84bbcadc31ea054d027af5312e462d267746ceb6acdc1"},
+]
+pyobjc-framework-naturallanguage = [
+    {file = "pyobjc-framework-NaturalLanguage-7.3.tar.gz", hash = "sha256:b48390651b857f6ed3fb3eeeb843f77cac033c32ad2bc367d4aeed17b63b1527"},
+    {file = "pyobjc_framework_NaturalLanguage-7.3-py2.py3-none-any.whl", hash = "sha256:a69dfdb67a9385aa37877046d42660f7da040beb182fd082dac6c203442911eb"},
+]
+pyobjc-framework-netfs = [
+    {file = "pyobjc-framework-NetFS-7.3.tar.gz", hash = "sha256:a5f6fb8ab739c9466ba9a81e3a742f92a8808e6716385aa15078630110f2ca6f"},
+    {file = "pyobjc_framework_NetFS-7.3-py2.py3-none-any.whl", hash = "sha256:b48377bf8490f0ce2f78c7f6dbc8e280d7c8a58d73e64c2a888d3f951a991a58"},
+]
+pyobjc-framework-network = [
+    {file = "pyobjc-framework-Network-7.3.tar.gz", hash = "sha256:c40fe885fcfc9e35680d81eb5a3b0bfc07e51b68039e928884da770bb0e45a78"},
+    {file = "pyobjc_framework_Network-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:094b2c63fcf1d29684fc2a0ab9c629620775ce1ac89026dbaafb22144e78304f"},
+    {file = "pyobjc_framework_Network-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:565761bada95e0d7912d4b2e5d17a201bb57be73321031a388bb301487a41b7d"},
+]
+pyobjc-framework-networkextension = [
+    {file = "pyobjc-framework-NetworkExtension-7.3.tar.gz", hash = "sha256:0bd2422628be9848297aa58c3b53af2da5c4dac8022d55684dae37e0264bfcf7"},
+    {file = "pyobjc_framework_NetworkExtension-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:099044b5846c5097c0b71b53511c6e6de9db68dfd2ddd62dc1d4253ea60ec76d"},
+    {file = "pyobjc_framework_NetworkExtension-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:f3b37e0cc7ff7d8adb10d85bacea1a3883379f01bb77de1e9155bd4395ddae09"},
+]
+pyobjc-framework-notificationcenter = [
+    {file = "pyobjc-framework-NotificationCenter-7.3.tar.gz", hash = "sha256:64866915bf4c20429fe27c2ab5ab86cab74fa0e557b24382c77a6a6d3d8878ea"},
+    {file = "pyobjc_framework_NotificationCenter-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:2186d4dcd6f56b567e72abc009b2c69f9bcb0ba42d61a987c057a257953a90be"},
+    {file = "pyobjc_framework_NotificationCenter-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:5765d0afb9716643d15ce52c66f3460898994b13084508c778c73430c8d2816d"},
+]
+pyobjc-framework-opendirectory = [
+    {file = "pyobjc-framework-OpenDirectory-7.3.tar.gz", hash = "sha256:2e60807e4385a0c781f4535af733a0ff38fc2c4fd29cb0622c0829b0e4ae34ac"},
+    {file = "pyobjc_framework_OpenDirectory-7.3-py2.py3-none-any.whl", hash = "sha256:fc12ec43d0faa7e83c45870ad5e58062a7299571bede4463a790a6e4bedaa5c4"},
+]
+pyobjc-framework-osakit = [
+    {file = "pyobjc-framework-OSAKit-7.3.tar.gz", hash = "sha256:eff377c2c5c8f498ee4522aff406dac17381fe88bf93bad474ba92f77cff6082"},
+    {file = "pyobjc_framework_OSAKit-7.3-py2.py3-none-any.whl", hash = "sha256:5e8ab0fb3c5ebd10cd1d2a1496e4517110f119e6947556546dc8121ba4d2f730"},
+]
+pyobjc-framework-oslog = [
+    {file = "pyobjc-framework-OSLog-7.3.tar.gz", hash = "sha256:251afa4a571f03a73b48807e95972eda9016746c08d55dcffad72454db485f86"},
+    {file = "pyobjc_framework_OSLog-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:734d1662b781e69e6096d24d908c52211ba3a54f97a21e30e5f22737269e709e"},
+    {file = "pyobjc_framework_OSLog-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:102ac6b834fc5e28f9c81f9760389d8d431001ecd12942d4464c24680084c09f"},
+]
+pyobjc-framework-passkit = [
+    {file = "pyobjc-framework-PassKit-7.3.tar.gz", hash = "sha256:10548941a9139bdd4469aeece4bb0aad7c5c28f57a19c54d7d78af6e779c5016"},
+    {file = "pyobjc_framework_PassKit-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:15fd2f0675428a40b0a64d672d3f33b8c708e13217cb3473c48d969d39d47c8f"},
+    {file = "pyobjc_framework_PassKit-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:1e80b0b52d4fec532c5d3d9065a5a14f731a35270038058be4f45be915ab2759"},
+]
+pyobjc-framework-pencilkit = [
+    {file = "pyobjc-framework-PencilKit-7.3.tar.gz", hash = "sha256:b2c12217c742e5acbffeb8d8b27f8a684ddfdbd0ade617db0865ae3c1955368a"},
+    {file = "pyobjc_framework_PencilKit-7.3-py2.py3-none-any.whl", hash = "sha256:4a065cb1dcd9ca92818fd045fc861f841b3204fb8ead95d2dda003553dbc0a47"},
+]
+pyobjc-framework-photos = [
+    {file = "pyobjc-framework-Photos-7.3.tar.gz", hash = "sha256:cf96b97b94f3f3c922966fa7637436adcfb72c24acd3a21bda327fd151e8b4f1"},
+    {file = "pyobjc_framework_Photos-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:835465b9be2c65afb13bad3b16056321b454c152426af1f3e05ec37165166c7f"},
+    {file = "pyobjc_framework_Photos-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:69d755187ec2e57a5005c49fb7f0aadbe4a6b1782c1a40c46a06762379deb51e"},
+]
+pyobjc-framework-photosui = [
+    {file = "pyobjc-framework-PhotosUI-7.3.tar.gz", hash = "sha256:34da58779d560949e9443ea79b26f36deb6e2a6ab17a8fc4f4d39d0190ba87a8"},
+    {file = "pyobjc_framework_PhotosUI-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:e2f879d61e81e281770a681e3f5e9c38b61a051400ca45b3cf4abc5680bf1e8b"},
+    {file = "pyobjc_framework_PhotosUI-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:b8e0839b5907619cc4071b012bcc942372be0ce0e6bfa63e32537faa6b48a620"},
+]
+pyobjc-framework-preferencepanes = [
+    {file = "pyobjc-framework-PreferencePanes-7.3.tar.gz", hash = "sha256:8aa2710d96d3d18f637ba53748225ed47ebc474fd0874cf8734c25d9c69f48f3"},
+    {file = "pyobjc_framework_PreferencePanes-7.3-py2.py3-none-any.whl", hash = "sha256:cf8cd47f615cce6b29da8ba4b44962b92aaebd27dcf20168e20999ababc25a81"},
+]
+pyobjc-framework-pubsub = [
+    {file = "pyobjc-framework-PubSub-7.3.tar.gz", hash = "sha256:1499e884b9b1e3fc8ced0e33fe6a4619af00359622969c45263d4192478edada"},
+    {file = "pyobjc_framework_PubSub-7.3-py2.py3-none-any.whl", hash = "sha256:cb7d6aac043446d654268e8b04fb2c0eed5c0f2d1d7e146812dd9a9f60f962cc"},
+]
+pyobjc-framework-pushkit = [
+    {file = "pyobjc-framework-PushKit-7.3.tar.gz", hash = "sha256:063579734da899a19fd0b67f75085c2b4c2295793889594a66dcdb2a5bd8fd9a"},
+    {file = "pyobjc_framework_PushKit-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:8cf280fc616dfc01072b774803b59ab2d444223f8fa53e8c3750bcff3f1fd63d"},
+    {file = "pyobjc_framework_PushKit-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:6dcf7c040727932ea68faf6509c06b7e505c1b4489114f3ba0d79267c9288ca4"},
+]
+pyobjc-framework-quartz = [
+    {file = "pyobjc-framework-Quartz-7.3.tar.gz", hash = "sha256:98812844c34262def980bdf60923a875cd43428a8375b6fd53bd2cd800eccf0b"},
+    {file = "pyobjc_framework_Quartz-7.3-1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:1139bc6874c0f8b58f0b8602015e0994198bc506a6bcec1071208de32b55ed26"},
+    {file = "pyobjc_framework_Quartz-7.3-1-cp38-cp38-macosx_11_0_universal2.whl", hash = "sha256:d94a3ed7051266c52392ec07d3b5adbf28d4be83341a24df0d88639344dcd84f"},
+    {file = "pyobjc_framework_Quartz-7.3-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:1ef18f5a16511ded65980bf4f5983ea5d35c88224dbad1b3112abd29c60413ea"},
+    {file = "pyobjc_framework_Quartz-7.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:3b41eec8d4b10c7c7e011e2f9051367f5499ef315ba52dfbae573c3a2e05469c"},
+    {file = "pyobjc_framework_Quartz-7.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:2c65456ed045dfe1711d0298734e5a3ad670f8c770f7eb3b19979256c388bdd2"},
+    {file = "pyobjc_framework_Quartz-7.3-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:8ddbca6b466584c3dc0e5b701b1c2a9b5d97ddc1d79a949927499ebb1be1f210"},
+    {file = "pyobjc_framework_Quartz-7.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:7aba3cd966a0768dd58a35680742820f0c5ac596a9cd11014e2057818e65b0af"},
+]
+pyobjc-framework-quicklookthumbnailing = [
+    {file = "pyobjc-framework-QuickLookThumbnailing-7.3.tar.gz", hash = "sha256:2308898f9c94370a99ab17fde0b713da0c9449ac22163cdb15e51a539834c3c7"},
+    {file = "pyobjc_framework_QuickLookThumbnailing-7.3-py2.py3-none-any.whl", hash = "sha256:699962a6c10168e7d59ec8467ef63fc0d50342545eb899215823551e4845040f"},
+]
+pyobjc-framework-replaykit = [
+    {file = "pyobjc-framework-ReplayKit-7.3.tar.gz", hash = "sha256:aec8f34fbbeb7aca9b4f1b285a4f2119035e4100249b8a64e84b144bb47a650d"},
+    {file = "pyobjc_framework_ReplayKit-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:4f85103fcbf10e09504405c58879637641d1112d165997e8c1a7825c7d90c75f"},
+    {file = "pyobjc_framework_ReplayKit-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:0457177b6bc5a2d88e7015a33835fea98d5d73e1c36e8fb78c8a88f6927058ff"},
+]
+pyobjc-framework-safariservices = [
+    {file = "pyobjc-framework-SafariServices-7.3.tar.gz", hash = "sha256:fd3d6878f0fd80a03ff343f8379af8060e5f33058ce279047ecb6e12304216cb"},
+    {file = "pyobjc_framework_SafariServices-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:5544485ddb68aa617a16a42200f345be95ef209af1a82a2f89a9d281b327219e"},
+    {file = "pyobjc_framework_SafariServices-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:ee66f939d96b853b70dda6e2b24b7b59dbc17ce10ffa225de3a1d124ba9fb784"},
+]
+pyobjc-framework-scenekit = [
+    {file = "pyobjc-framework-SceneKit-7.3.tar.gz", hash = "sha256:4adc7e82784f5277f24305c08761936a329020f664fb7da4dc9b9b7a64990b1a"},
+    {file = "pyobjc_framework_SceneKit-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:977fa65fcf5d8012b0d7c8f3d7a2bd9aa7c685a83b6850d74faddab04e6fdab3"},
+    {file = "pyobjc_framework_SceneKit-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:14d2c4af8324e34c71d1fdb5a1af4c85b644c7142d61ebb30b495e12edd068e1"},
+]
+pyobjc-framework-screensaver = [
+    {file = "pyobjc-framework-ScreenSaver-7.3.tar.gz", hash = "sha256:b4d13cc2d54675893aed6d2fa60cf8d134fa821e9cce7b224756fa3e260a548f"},
+    {file = "pyobjc_framework_ScreenSaver-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:9bbb9ef9db8c73bbdb92c5ddca21e64f2f414b2e50dab3f143539834b11982d0"},
+    {file = "pyobjc_framework_ScreenSaver-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:ed8968225a6a84249cd984baeb09b03ac372c03195f99114673400ec617ccb8e"},
+]
+pyobjc-framework-screentime = [
+    {file = "pyobjc-framework-ScreenTime-7.3.tar.gz", hash = "sha256:96f25c23321f92eb4da9a75e10d778484e5a99e74e14971783354a5047f765ea"},
+    {file = "pyobjc_framework_ScreenTime-7.3-py2.py3-none-any.whl", hash = "sha256:7dbb5225ccf97ef809a147ad1785b45aba3e76d7a8e0aceac92e7293ae680fc5"},
+]
+pyobjc-framework-scriptingbridge = [
+    {file = "pyobjc-framework-ScriptingBridge-7.3.tar.gz", hash = "sha256:f09f4cad708d3c946bbcf7fdc5e623bbb512e4e0b085536fc22fe1131b517ca9"},
+    {file = "pyobjc_framework_ScriptingBridge-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:903d70ed128709e3be06c033cc6c421b26658f67dc628b92e6190b1fd1150e59"},
+    {file = "pyobjc_framework_ScriptingBridge-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:b8f071751845253469d7a2cd8e2fae9c35ea0015789030e1ad1b958fb53dc82f"},
+]
+pyobjc-framework-searchkit = [
+    {file = "pyobjc-framework-SearchKit-7.3.tar.gz", hash = "sha256:80fc90c95cf14a0f4cc589764f329211e20e02f51840e880c802603c9dc41497"},
+    {file = "pyobjc_framework_SearchKit-7.3-py2.py3-none-any.whl", hash = "sha256:9619b301411b2d0f9436758691b8f4dae8bf8b95a85fd6c66a422cfd15750943"},
+]
+pyobjc-framework-security = [
+    {file = "pyobjc-framework-Security-7.3.tar.gz", hash = "sha256:4109ab15faf2dcf89646330a4f0a6584410d7134418fae0814858cab4ab76347"},
+    {file = "pyobjc_framework_Security-7.3-1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:57ef7656f01bfdd1dfddc3493e90abc74910379bd9319f764d1ac09fc7c470dc"},
+    {file = "pyobjc_framework_Security-7.3-1-cp38-cp38-macosx_11_0_universal2.whl", hash = "sha256:1470400a48cc7e1eab48e67611cd1c551c28d3c39ef4f7ece3a35c52b6694c43"},
+    {file = "pyobjc_framework_Security-7.3-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:1a048e42ddca426ac02838e8f4093f138b1fd88f9de8c3c5f087fbaa60cd1987"},
+    {file = "pyobjc_framework_Security-7.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:77d0c4b68d1409719f7bc023719b1f1a066e48f270bcfedb700b342523b191be"},
+    {file = "pyobjc_framework_Security-7.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:379287b0a01abc047bee7d2632fa34f038faa8f566c3de6978141bfcf3fc6128"},
+    {file = "pyobjc_framework_Security-7.3-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:966a59f59b57da0cbea0b9d0e59bae0d61e631b5cd0a336982e50705dfaf37a5"},
+    {file = "pyobjc_framework_Security-7.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:b6bd5ba1443f2c7d47fa9f4e1257e7e32e00f452a251b5955fa2ba03c032c11d"},
+]
+pyobjc-framework-securityfoundation = [
+    {file = "pyobjc-framework-SecurityFoundation-7.3.tar.gz", hash = "sha256:b37b2ebc737cf79dece2afadaeb1a93a2a1346280f38ffe4baa7681a9c3298ce"},
+    {file = "pyobjc_framework_SecurityFoundation-7.3-py2.py3-none-any.whl", hash = "sha256:f7518fa4be99e4dac5c967fcf190777fc54f6c9f1e1917222f7d3f073ad19d7f"},
+]
+pyobjc-framework-securityinterface = [
+    {file = "pyobjc-framework-SecurityInterface-7.3.tar.gz", hash = "sha256:e240be5bd5de8783bd98a36018a51a104a267459ce527af8b28b22f66ee299ce"},
+    {file = "pyobjc_framework_SecurityInterface-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:da76ffd44a26cf56a194cbc02bf28ef71753ad8ce2beb69a1281fa71d6f6e246"},
+    {file = "pyobjc_framework_SecurityInterface-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:7aae7ca82bad629ef620f99b5c696bd011bec5354d29c933715dc49e9a19536b"},
+]
+pyobjc-framework-servernotification = [
+    {file = "pyobjc-framework-ServerNotification-7.3.tar.gz", hash = "sha256:aa8ba576a020a567016d36c6ce5fd9f6f8bd0f93c2bfb2b07420eb54ba514cd8"},
+    {file = "pyobjc_framework_ServerNotification-7.3-py2.py3-none-any.whl", hash = "sha256:40e0ec87d69b0c27d9be07ee0265eca9a4a9fad5b7ffa2e66bdcf189f86b4561"},
+]
+pyobjc-framework-servicemanagement = [
+    {file = "pyobjc-framework-ServiceManagement-7.3.tar.gz", hash = "sha256:f3106b96347c7bf60045ffaee917235442cd1d9254a03e10f9bc648ccbbc3b55"},
+    {file = "pyobjc_framework_ServiceManagement-7.3-py2.py3-none-any.whl", hash = "sha256:9fff8afbcb69c5509485c9df457b79ee7c79850e9099964458f5fc921a4f3b8f"},
+]
+pyobjc-framework-social = [
+    {file = "pyobjc-framework-Social-7.3.tar.gz", hash = "sha256:bc6f5e1566ae47d2083d9dc9d0903210b934e5abdc81a211f10ff0fa05df1e0d"},
+    {file = "pyobjc_framework_Social-7.3-py2.py3-none-any.whl", hash = "sha256:ba03559d4e6837e3454440011b1310b4f9f127faf7bb111f00b6572db8325770"},
+]
+pyobjc-framework-soundanalysis = [
+    {file = "pyobjc-framework-SoundAnalysis-7.3.tar.gz", hash = "sha256:702cd6a3ff022370421182244161310551fe4927aea20b89f66615c7abc859eb"},
+    {file = "pyobjc_framework_SoundAnalysis-7.3-py2.py3-none-any.whl", hash = "sha256:8c29f61010a53b2da7a9f394fc52618be1c3f30e4a2359958a574fbd4705ab31"},
+]
+pyobjc-framework-speech = [
+    {file = "pyobjc-framework-Speech-7.3.tar.gz", hash = "sha256:9c6ef27d8381a065e43c23101c24d23d4f2a3d1ae62ee8afd5d36de1781f3e64"},
+    {file = "pyobjc_framework_Speech-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:467320a7dd6e2eb3328c61c106bc41971e256feeed523d42895eee69a08f3fa0"},
+    {file = "pyobjc_framework_Speech-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:da52b8860375108807604ca947ede123123a07b70cf0ee063728233ba57cfb77"},
+]
+pyobjc-framework-spritekit = [
+    {file = "pyobjc-framework-SpriteKit-7.3.tar.gz", hash = "sha256:0a6a6a0821e8eacf56f847a1b68c62db6484b37588a84677aca44e2a41c39c67"},
+    {file = "pyobjc_framework_SpriteKit-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:b47beedfd4f15a517b0f162ccf752d1367c24190e89239da961e8681a6f8a35c"},
+    {file = "pyobjc_framework_SpriteKit-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:1d0d7afa295d8926b2b8bd69f700b9039c35ac95323c1b3cc5023d312d60ec6f"},
+]
+pyobjc-framework-storekit = [
+    {file = "pyobjc-framework-StoreKit-7.3.tar.gz", hash = "sha256:b9542b8a2a3ef7feb27ef6de7819b0657ec51db78235a5004f7d1444c0f19f56"},
+    {file = "pyobjc_framework_StoreKit-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:4e77ef9da46a12bc43294a053853b53c3dd026f68b2df6e779bca13ca80a2b13"},
+    {file = "pyobjc_framework_StoreKit-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:1980195a5f4ab6277eb4a52e7ad0995af613c0cd4e13e43f1435f567c1a3ec37"},
+]
+pyobjc-framework-syncservices = [
+    {file = "pyobjc-framework-SyncServices-7.3.tar.gz", hash = "sha256:e63bba4e855d1683d249017fbbbb09a8699f9258f3214014aa3ba4341506e165"},
+    {file = "pyobjc_framework_SyncServices-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:efef2c69b1dc0c9d558ee04e161dc937e02329a2451f002d3455b21ea1da11d3"},
+    {file = "pyobjc_framework_SyncServices-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:85d7519646d0faaee9b188d7f733d7629f292043eb1e37a840b1e3f785e13884"},
+]
+pyobjc-framework-systemconfiguration = [
+    {file = "pyobjc-framework-SystemConfiguration-7.3.tar.gz", hash = "sha256:92cbe14d9efcf1c52328ab1ba4cc359879c22e2f390179ec4713af176bc19dc6"},
+    {file = "pyobjc_framework_SystemConfiguration-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:c5b5e9d852a15165507a46b8c8974e6d99aff3d1edda4d77443530b604adb520"},
+    {file = "pyobjc_framework_SystemConfiguration-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:05293ef0a358fbefd41d4470a98c7c08f70ace3d09245b7c7370228d8068b328"},
+]
+pyobjc-framework-systemextensions = [
+    {file = "pyobjc-framework-SystemExtensions-7.3.tar.gz", hash = "sha256:d175f0fba9a571af78c333285f5b1cd310e83453dc018ae5663adcd53aef4d0d"},
+    {file = "pyobjc_framework_SystemExtensions-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:85810b03a7b1a4034bb0cd39eac5d0d38be7e602aa5805759944972bd50ce44d"},
+    {file = "pyobjc_framework_SystemExtensions-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:d45297f24cf411d62367c706d080b594620359195eb623bd3f9ea523dfb79b54"},
+]
+pyobjc-framework-uniformtypeidentifiers = [
+    {file = "pyobjc-framework-UniformTypeIdentifiers-7.3.tar.gz", hash = "sha256:f827ca61d5dcd82343178d1d6a6a5e9be8f721f51a4feba4c3a3a39afaa674d5"},
+    {file = "pyobjc_framework_UniformTypeIdentifiers-7.3-py2.py3-none-any.whl", hash = "sha256:62f043d566b3bf37b8324c98a6ae4b449b523cb3027d17eb5d2d8c4ce119f99c"},
+]
+pyobjc-framework-usernotifications = [
+    {file = "pyobjc-framework-UserNotifications-7.3.tar.gz", hash = "sha256:40f60d4d0eb575e5d23d3d0bb5fcbdf444cf80ce91f5235c634e336416f91934"},
+    {file = "pyobjc_framework_UserNotifications-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:814891723e45c380fa4d619bc77b23f8d3b846ddf4059488b2424d8b085e9105"},
+    {file = "pyobjc_framework_UserNotifications-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:88a74333013bd921af44d11211c1a6198f66add2ac506e6ce4b5c09991f3f024"},
+]
+pyobjc-framework-usernotificationsui = [
+    {file = "pyobjc-framework-UserNotificationsUI-7.3.tar.gz", hash = "sha256:02b639f06d0a394b4fd45068c6b74250f1033049d74f1a2b2533822aa114605b"},
+    {file = "pyobjc_framework_UserNotificationsUI-7.3-py2.py3-none-any.whl", hash = "sha256:36b17214c55bd38988c9f039029a4faf49c15071ffc586664474a2c8190c1f2c"},
+]
+pyobjc-framework-videosubscriberaccount = [
+    {file = "pyobjc-framework-VideoSubscriberAccount-7.3.tar.gz", hash = "sha256:0dddf8bbfe70e1fd1e5ef4d29fff097c00f33357807a958676d3b52944eaebfa"},
+    {file = "pyobjc_framework_VideoSubscriberAccount-7.3-py2.py3-none-any.whl", hash = "sha256:deef5975537cce391915f93434b5d67b4788f08e3e91de802c48966b22643a52"},
+]
+pyobjc-framework-videotoolbox = [
+    {file = "pyobjc-framework-VideoToolbox-7.3.tar.gz", hash = "sha256:e32eb1374dd42f4dc8d8bddb7f7f48dde0d7e1fde7181effdf15df8144b85c8e"},
+    {file = "pyobjc_framework_VideoToolbox-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:8dd4dae4c34085ea8bbcf65ea63358859f5621c55ac7db9ab37d6c45719d117d"},
+    {file = "pyobjc_framework_VideoToolbox-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:326fe057c65ec8df3198488e4e5250e0f6a9ab7fa2b0a5378ab6137f4377a47e"},
+]
+pyobjc-framework-virtualization = [
+    {file = "pyobjc-framework-Virtualization-7.3.tar.gz", hash = "sha256:57f8ec5386f063d281a2c235cf1f1ef5181f2376cd53bd484018e50b4dcf2eb8"},
+    {file = "pyobjc_framework_Virtualization-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:5e7b183ee22c914fc203def08abcab74daab0bebbd6f0cfc53251321dffc2f07"},
+    {file = "pyobjc_framework_Virtualization-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:195fda568a0eebac87aa515232f2db765845c74daf903774616acbe8cb61263e"},
+]
+pyobjc-framework-vision = [
+    {file = "pyobjc-framework-Vision-7.3.tar.gz", hash = "sha256:cab1fdf6b02a1767646cf6353a118c0fa5d420fca4ab3904ce5054332f59f424"},
+    {file = "pyobjc_framework_Vision-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:09b1f55b731aaf3cad68a27b47c3bd93d2c88d8cf16d0c0157dd51151f5f0bbd"},
+    {file = "pyobjc_framework_Vision-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:a81ac37e5f4c89d56046b9c551d16d16d0fcfe077678d0f2bd5bf62f418d00f0"},
+]
+pyobjc-framework-webkit = [
+    {file = "pyobjc-framework-WebKit-7.3.tar.gz", hash = "sha256:bec3a985c0f5e4263d6e28e2c551c1b5ec7b63950e0e3cb5409abdbf61f11f01"},
+    {file = "pyobjc_framework_WebKit-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:cd388df8fde96db724a42745395998b6d5a98740fb29bac95f76884e2fa6bf27"},
+    {file = "pyobjc_framework_WebKit-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:89e0fcc10eb09e4203b1ace02808ae9b1882b6c8a55bbfaff20213e2a62ce974"},
+]
+pyperclip = [
+    {file = "pyperclip-1.8.2.tar.gz", hash = "sha256:105254a8b04934f0bc84e9c24eb360a591aaf6535c9def5f29d92af107a9bf57"},
+]
+pyrect = [
+    {file = "PyRect-0.1.4.tar.gz", hash = "sha256:3b2fa7353ce32a11aa6b0a15495968d2a763423c8947ae248b92c037def4e202"},
+]
+pyscreeze = [
+    {file = "PyScreeze-0.1.28.tar.gz", hash = "sha256:4428600ed19b30cd3f4b5d83767d198fc1dbae7439eecf9bd795445c009b67ae"},
+]
+python3-xlib = [
+    {file = "python3-xlib-0.15.tar.gz", hash = "sha256:dc4245f3ae4aa5949c1d112ee4723901ade37a96721ba9645f2bfa56e5b383f8"},
+]
+pytweening = [
+    {file = "pytweening-1.0.4.tar.gz", hash = "sha256:8533282cf70b31de8a0499e1cf420930b0013c787118872b2ec899382792e2e6"},
+]
+regex = [
+    {file = "regex-2021.9.30-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:66696c8336a1b5d1182464f3af3427cc760118f26d0b09a2ddc16a976a4d2637"},
+    {file = "regex-2021.9.30-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4d87459ad3ab40cd8493774f8a454b2e490d8e729e7e402a0625867a983e4e02"},
+    {file = "regex-2021.9.30-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:78cf6a1e023caf5e9a982f5377414e1aeac55198831b852835732cfd0a0ca5ff"},
+    {file = "regex-2021.9.30-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:255791523f80ea8e48e79af7120b4697ef3b74f6886995dcdb08c41f8e516be0"},
+    {file = "regex-2021.9.30-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e502f8d4e5ef714bcc2c94d499684890c94239526d61fdf1096547db91ca6aa6"},
+    {file = "regex-2021.9.30-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:4907fb0f9b9309a5bded72343e675a252c2589a41871874feace9a05a540241e"},
+    {file = "regex-2021.9.30-cp310-cp310-win32.whl", hash = "sha256:3be40f720af170a6b20ddd2ad7904c58b13d2b56f6734ee5d09bbdeed2fa4816"},
+    {file = "regex-2021.9.30-cp310-cp310-win_amd64.whl", hash = "sha256:c2b180ed30856dfa70cfe927b0fd38e6b68198a03039abdbeb1f2029758d87e7"},
+    {file = "regex-2021.9.30-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:e6f2d2f93001801296fe3ca86515eb04915472b5380d4d8752f09f25f0b9b0ed"},
+    {file = "regex-2021.9.30-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4fa7ba9ab2eba7284e0d7d94f61df7af86015b0398e123331362270d71fab0b9"},
+    {file = "regex-2021.9.30-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:28040e89a04b60d579c69095c509a4f6a1a5379cd865258e3a186b7105de72c6"},
+    {file = "regex-2021.9.30-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:f588209d3e4797882cd238195c175290dbc501973b10a581086b5c6bcd095ffb"},
+    {file = "regex-2021.9.30-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:42952d325439ef223e4e9db7ee6d9087b5c68c5c15b1f9de68e990837682fc7b"},
+    {file = "regex-2021.9.30-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:cae4099031d80703954c39680323dabd87a69b21262303160776aa0e55970ca0"},
+    {file = "regex-2021.9.30-cp36-cp36m-win32.whl", hash = "sha256:0de8ad66b08c3e673b61981b9e3626f8784d5564f8c3928e2ad408c0eb5ac38c"},
+    {file = "regex-2021.9.30-cp36-cp36m-win_amd64.whl", hash = "sha256:b345ecde37c86dd7084c62954468a4a655fd2d24fd9b237949dd07a4d0dd6f4c"},
+    {file = "regex-2021.9.30-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:a6f08187136f11e430638c2c66e1db091105d7c2e9902489f0dbc69b44c222b4"},
+    {file = "regex-2021.9.30-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b55442650f541d195a535ccec33078c78a9521973fb960923da7515e9ed78fa6"},
+    {file = "regex-2021.9.30-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:87e9c489aa98f50f367fb26cc9c8908d668e9228d327644d7aa568d47e456f47"},
+    {file = "regex-2021.9.30-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:e2cb7d4909ed16ed35729d38af585673f1f0833e73dfdf0c18e5be0061107b99"},
+    {file = "regex-2021.9.30-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d0861e7f6325e821d5c40514c551fd538b292f8cc3960086e73491b9c5d8291d"},
+    {file = "regex-2021.9.30-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:81fdc90f999b2147fc62e303440c424c47e5573a9b615ed5d43a5b832efcca9e"},
+    {file = "regex-2021.9.30-cp37-cp37m-win32.whl", hash = "sha256:8c1ad61fa024195136a6b7b89538030bd00df15f90ac177ca278df9b2386c96f"},
+    {file = "regex-2021.9.30-cp37-cp37m-win_amd64.whl", hash = "sha256:e3770781353a4886b68ef10cec31c1f61e8e3a0be5f213c2bb15a86efd999bc4"},
+    {file = "regex-2021.9.30-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:9c065d95a514a06b92a5026766d72ac91bfabf581adb5b29bc5c91d4b3ee9b83"},
+    {file = "regex-2021.9.30-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9925985be05d54b3d25fd6c1ea8e50ff1f7c2744c75bdc4d3b45c790afa2bcb3"},
+    {file = "regex-2021.9.30-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:470f2c882f2672d8eeda8ab27992aec277c067d280b52541357e1acd7e606dae"},
+    {file = "regex-2021.9.30-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:ad0517df22a97f1da20d8f1c8cb71a5d1997fa383326b81f9cf22c9dadfbdf34"},
+    {file = "regex-2021.9.30-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c9e30838df7bfd20db6466fd309d9b580d32855f8e2c2e6d74cf9da27dcd9b63"},
+    {file = "regex-2021.9.30-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:5b34d2335d6aedec7dcadd3f8283b9682fadad8b9b008da8788d2fce76125ebe"},
+    {file = "regex-2021.9.30-cp38-cp38-win32.whl", hash = "sha256:e07049cece3462c626d650e8bf42ddbca3abf4aa08155002c28cb6d9a5a281e2"},
+    {file = "regex-2021.9.30-cp38-cp38-win_amd64.whl", hash = "sha256:37868075eda024470bd0feab872c692ac4ee29db1e14baec103257bf6cc64346"},
+    {file = "regex-2021.9.30-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:d331f238a7accfbbe1c4cd1ba610d4c087b206353539331e32a8f05345c74aec"},
+    {file = "regex-2021.9.30-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6348a7ab2a502cbdd0b7fd0496d614007489adb7361956b38044d1d588e66e04"},
+    {file = "regex-2021.9.30-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ce7b1cca6c23f19bee8dc40228d9c314d86d1e51996b86f924aca302fc8f8bf9"},
+    {file = "regex-2021.9.30-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:1f1125bc5172ab3a049bc6f4b9c0aae95a2a2001a77e6d6e4239fa3653e202b5"},
+    {file = "regex-2021.9.30-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:638e98d069b14113e8afba6a54d1ca123f712c0d105e67c1f9211b2a825ef926"},
+    {file = "regex-2021.9.30-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:9a0b0db6b49da7fa37ca8eddf9f40a8dbc599bad43e64f452284f37b6c34d91c"},
+    {file = "regex-2021.9.30-cp39-cp39-win32.whl", hash = "sha256:9910869c472e5a6728680ca357b5846546cbbd2ab3ad5bef986ef0bc438d0aa6"},
+    {file = "regex-2021.9.30-cp39-cp39-win_amd64.whl", hash = "sha256:3b71213ec3bad9a5a02e049f2ec86b3d7c3e350129ae0f4e2f99c12b5da919ed"},
+    {file = "regex-2021.9.30.tar.gz", hash = "sha256:81e125d9ba54c34579e4539a967e976a3c56150796674aec318b1b2f49251be7"},
+]
+rubicon-objc = [
+    {file = "rubicon-objc-0.4.1.tar.gz", hash = "sha256:e6de491187445704e03a653840904b5252c9345ec1d0ab94922a1e7711623bc3"},
+    {file = "rubicon_objc-0.4.1-py3-none-any.whl", hash = "sha256:8b4482792c189b0642da7649d81267e2c405ac1b2aa4c8e254a7f96a63f4805e"},
+]
+toml = [
+    {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},
+    {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
+]
+tomli = [
+    {file = "tomli-1.2.1-py3-none-any.whl", hash = "sha256:8dd0e9524d6f386271a36b41dbf6c57d8e32fd96fd22b6584679dc569d20899f"},
+    {file = "tomli-1.2.1.tar.gz", hash = "sha256:a5b75cb6f3968abb47af1b40c1819dc519ea82bcc065776a866e8d74c5ca9442"},
+]
+typing-extensions = [
+    {file = "typing_extensions-3.10.0.2-py2-none-any.whl", hash = "sha256:d8226d10bc02a29bcc81df19a26e56a9647f8b0a6d4a83924139f4a8b01f17b7"},
+    {file = "typing_extensions-3.10.0.2-py3-none-any.whl", hash = "sha256:f1d25edafde516b146ecd0613dabcc61409817af4766fbbcfb8d1ad4ec441a34"},
+    {file = "typing_extensions-3.10.0.2.tar.gz", hash = "sha256:49f75d16ff11f1cd258e1b988ccff82a3ca5570217d7ad8c5f48205dd99a677e"},
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,22 @@
+[tool.poetry]
+name = "airdrum-app"
+version = "0.1.0"
+description = ""
+authors = ["Your Name <you@example.com>"]
+
+[tool.poetry.dependencies]
+python = ">=3.9,<3.11"
+numpy = "^1.21.2"
+PyAutoGUI = "^0.9.53"
+imutils = "^0.5.4"
+opencv-python = "^4.5.3"
+
+[tool.poetry.dev-dependencies]
+black = "^21.9b0"
+isort = "^5.9.3"
+flake8 = "^3.9.2"
+mypy = "^0.910"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
Esse PR adiciona um arquivo pra gerenciamento de dependencias do python via a ferramenta Poetry. 

Mesmo sem o poetry, com o arquivo `pyproject.toml` agora é possível instalar todas dependencias do projeto usando `pip install .`, é análogo ao `requirements.txt` que talvez já tenha visto antes.